### PR TITLE
Add simple usage options to do a basic set up without amqpprox_ctl

### DIFF
--- a/amqpprox/amqpprox.m.cpp
+++ b/amqpprox/amqpprox.m.cpp
@@ -77,7 +77,6 @@ Although most configuration is injected by the amqpprox_ctl program, the logging
 )helptext";
 }
 
-// TODO update this HELP_TEXT
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
This is for internal request #74

This adds some options onto the amqpprox main binary that allows the most basic configuration of all traffic from one port to another DNS name + port to be done without using amqpprox_ctl. It also adds the ability to set the console verbosity.