### PR TITLE
PacketProcessor: Permit AMQP protocol header being split across multiple reads

### DIFF
--- a/libamqpprox/amqpprox_connector.cpp
+++ b/libamqpprox/amqpprox_connector.cpp
@@ -67,7 +67,8 @@ void Connector::receive(const Buffer &buffer)
             d_state = State::START_SENT;
         }
         else {
-            LOG_WARN << "Incorrect header passed";
+            LOG_WARN << "Incorrect header passed. " << buffer.size()
+                     << "bytes";
             d_buffer            = protocolHeader;
             d_sendToIngressSide = true;
             d_state             = State::ERROR;

--- a/libamqpprox/amqpprox_packetprocessor.cpp
+++ b/libamqpprox/amqpprox_packetprocessor.cpp
@@ -18,6 +18,7 @@
 
 #include <amqpprox_buffer.h>
 #include <amqpprox_connector.h>
+#include <amqpprox_constants.h>
 #include <amqpprox_frame.h>
 #include <amqpprox_logging.h>
 #include <amqpprox_method.h>
@@ -51,6 +52,15 @@ void PacketProcessor::process(FlowType direction, const Buffer &readBuffer)
     const void *nextFrame = readBuffer.originalPtr();
 
     if (d_connector.state() == Connector::State::AWAITING_PROTOCOL_HEADER) {
+        if (remaining < Constants::protocolHeaderLength()) {
+            LOG_DEBUG << "Haven't quite read enough for full protocol header: "
+                      << remaining;
+
+            d_remainingBuffer =
+                Buffer(readBuffer.originalPtr(), remaining);
+            return;
+        }
+
         d_connector.receive(readBuffer.currentData());
 
         if (d_connector.sendToIngressSide()) {

--- a/tests/amqpprox_packetprocessor.t.cpp
+++ b/tests/amqpprox_packetprocessor.t.cpp
@@ -15,4 +15,124 @@
 */
 #include <amqpprox_packetprocessor.h>
 
+#include <amqpprox_buffer.h>
+#include <amqpprox_bufferpool.h>
+#include <amqpprox_connector.h>
+#include <amqpprox_dnshostnamemapper.h>
+#include <amqpprox_eventsource.h>
+#include <amqpprox_flowtype.h>
+#include <amqpprox_frame.h>
+#include <amqpprox_sessionstate.h>
+
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+using namespace ::testing;
+
+class PacketProcessorTest : public ::testing::Test {
+  public:
+    PacketProcessorTest()
+    : d_pool({32,
+              64,
+              128,
+              256,
+              512,
+              1024,
+              4096,
+              16384,
+              32768,
+              65536,
+              Frame::getMaxFrameSize()})
+    , d_eventSource()
+    , d_mapper(std::make_shared<DNSHostnameMapper>())
+    , d_sessionState(d_mapper)
+    , d_connector(&d_sessionState, &d_eventSource, &d_pool, "hostname")
+    {
+    }
+
+    BufferPool                         d_pool;
+    EventSource                        d_eventSource;
+    std::shared_ptr<DNSHostnameMapper> d_mapper;
+
+    SessionState d_sessionState;
+    Connector    d_connector;
+};
+
+TEST_F(PacketProcessorTest, Breathing)
+{
+    PacketProcessor processor(d_sessionState, d_connector);
+    EXPECT_THAT(d_connector.state(),
+                Eq(Connector::State::AWAITING_PROTOCOL_HEADER));
+}
+
+TEST_F(PacketProcessorTest, HeaderPassedInOne)
+{
+    // If we get a full AMQP header the Connector should move state
+    PacketProcessor processor(d_sessionState, d_connector);
+
+    Buffer buffer((const void *)Constants::protocolHeader(),
+                  Constants::protocolHeaderLength());
+    buffer.seek(Constants::protocolHeaderLength());
+
+    processor.process(FlowType::INGRESS, buffer);
+
+    EXPECT_THAT(processor.remaining().size(), Eq(0));
+    EXPECT_THAT(d_connector.state(), Eq(Connector::State::START_SENT));
+}
+
+TEST_F(PacketProcessorTest, IncompleteHeader)
+{
+    // If we give the PacketProcessor less than the full header, we shouldn't
+    // move on yet
+    const size_t halfHeader = 4;
+
+    Buffer buffer((const void *)Constants::protocolHeader(), halfHeader);
+    buffer.seek(halfHeader);
+
+    PacketProcessor processor(d_sessionState, d_connector);
+    processor.process(FlowType::INGRESS, buffer);
+
+    Buffer remaining = processor.remaining();
+
+    EXPECT_THAT(remaining.size(), Eq(4));
+    EXPECT_TRUE(remaining.equalContents(buffer));
+
+    EXPECT_THAT(d_connector.state(),
+                Eq(Connector::State::AWAITING_PROTOCOL_HEADER));
+}
+
+TEST_F(PacketProcessorTest, IncompleteHeaderInLargerBuffer)
+{
+    // Setup a 1024 byte buffer with 4 bytes written to it
+    const size_t         bufferSize = 1024;
+    std::vector<uint8_t> data;
+    data.resize(bufferSize);
+
+    const size_t halfHeader = 4;
+    Buffer       buffer((const void *)data.data(), bufferSize);
+    memcpy(buffer.ptr(), Constants::protocolHeader(), halfHeader);
+    buffer.seek(halfHeader);
+
+    // Process the buffer
+    PacketProcessor processor(d_sessionState, d_connector);
+    processor.process(FlowType::INGRESS, buffer);
+
+    // Expect that the data marked as remaining contains just the half header
+    Buffer expectedBuffer((const void *)Constants::protocolHeader(),
+                          halfHeader);
+    expectedBuffer.seek(halfHeader);
+
+    Buffer remaining = processor.remaining();
+    EXPECT_THAT(remaining.size(), Eq(4));
+    EXPECT_TRUE(remaining.equalContents(expectedBuffer));
+
+    // And that the Connector is still awaiting a full protocol header
+    EXPECT_THAT(d_connector.state(),
+                Eq(Connector::State::AWAITING_PROTOCOL_HEADER));
+}
+
+}
+}


### PR DESCRIPTION
Noticed while testing TLS that it's possible for the AMQP 0.9.1 header
to be split across multiple reads. Although it's best practice to always handle
this for tcp sockets it's still very surprising we hit this problem on an 8 byte header, even with
TLS enabled. From testing on my machine it feels fairly common though - perhaps even more so with proxy protocol?

A log search for 'Incorrect header passed' also shows a reasonable number of
results in the last 30 days. I'm not sure if this shows an actual issue
or a rogue healthcheck.