### PR TITLE
Add auth gate service interface

### DIFF
--- a/libamqpprox/CMakeLists.txt
+++ b/libamqpprox/CMakeLists.txt
@@ -80,7 +80,11 @@ add_library(libamqpprox STATIC
     amqpprox_methods_tune.cpp
     amqpprox_methods_tuneok.cpp
     amqpprox_methods_start.cpp
-    amqpprox_methods_startok.cpp)
+    amqpprox_methods_startok.cpp
+    amqpprox_authinterceptinterface.cpp
+    amqpprox_authrequestdata.cpp
+    amqpprox_authresponsedata.cpp
+    amqpprox_defaultauthintercept.cpp)
 
 target_link_libraries(libamqpprox LINK_PUBLIC ${LIBAMQPPROX_LIBS})
 

--- a/libamqpprox/amqpprox_authinterceptinterface.cpp
+++ b/libamqpprox/amqpprox_authinterceptinterface.cpp
@@ -1,0 +1,31 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_authinterceptinterface.h>
+
+#include <boost/asio.hpp>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+AuthInterceptInterface::AuthInterceptInterface(
+    boost::asio::io_service &ioService)
+: d_ioService(ioService)
+{
+}
+
+}
+}

--- a/libamqpprox/amqpprox_authinterceptinterface.h
+++ b/libamqpprox/amqpprox_authinterceptinterface.h
@@ -1,0 +1,71 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef BLOOMBERG_AMQPPROX_AUTHINTERCEPTINTERFACE
+#define BLOOMBERG_AMQPPROX_AUTHINTERCEPTINTERFACE
+
+#include <amqpprox_authrequestdata.h>
+#include <amqpprox_authresponsedata.h>
+
+#include <functional>
+#include <iostream>
+
+#include <boost/asio.hpp>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+/**
+ * \brief Provide a pure virtual interface for authn/authz operations
+ */
+class AuthInterceptInterface {
+  protected:
+    boost::asio::io_service &d_ioService;
+
+  public:
+    /**
+     * \brief Callback function to return response allow/deny with reason after
+     * authenticating client connection.
+     */
+    typedef std::function<void(const AuthResponseData &)> ReceiveResponseCb;
+
+    // CREATORS
+    explicit AuthInterceptInterface(boost::asio::io_service &ioService);
+
+    virtual ~AuthInterceptInterface() = default;
+
+    // MANIPULATORS
+    /**
+     * \brief It gets all the information required to authenticate from client
+     * in authRequestData parameter and invoke callback function to provide
+     * response.
+     * \param authRequestData auth request data payload
+     * \param responseCb Callbak function with response values
+     */
+    virtual void authenticate(const AuthRequestData    authRequestData,
+                              const ReceiveResponseCb &responseCb) = 0;
+
+    // ACCESSORS
+    /**
+     * \brief Print information about route auth gate service
+     * \param os output stream object
+     */
+    virtual void print(std::ostream &os) const = 0;
+};
+
+}
+}
+
+#endif

--- a/libamqpprox/amqpprox_authrequestdata.cpp
+++ b/libamqpprox/amqpprox_authrequestdata.cpp
@@ -1,0 +1,39 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_authrequestdata.h>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+AuthRequestData::AuthRequestData(std::string_view vhostName,
+                                 std::string_view authMechanism,
+                                 std::string_view credentials)
+: d_vhostName(vhostName)
+, d_authMechanism(authMechanism)
+, d_credentials(credentials)
+{
+}
+
+AuthRequestData::AuthRequestData()
+: d_vhostName()
+, d_authMechanism()
+, d_credentials()
+{
+}
+
+}
+}

--- a/libamqpprox/amqpprox_authrequestdata.h
+++ b/libamqpprox/amqpprox_authrequestdata.h
@@ -1,0 +1,51 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef BLOOMBERG_AMQPPROX_AUTHREQUESTDATA
+#define BLOOMBERG_AMQPPROX_AUTHREQUESTDATA
+
+#include <string>
+#include <string_view>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+/**
+ * \brief Provide a class to hold request data for authn/authz operations
+ */
+class AuthRequestData {
+    std::string d_vhostName;
+    std::string d_authMechanism;
+    std::string d_credentials;
+
+  public:
+    /**
+     * \brief Create and initialize object of AuthRequestData class
+     * \param vhostName vhost name
+     * \param authMechanism authentication mechanism field for START-OK
+     * connection method
+     * \param credentials response field for START-OK connection method
+     */
+    AuthRequestData(std::string_view vhostName,
+                    std::string_view authMechanism,
+                    std::string_view credentials);
+
+    AuthRequestData();
+};
+
+}
+}
+
+#endif

--- a/libamqpprox/amqpprox_authresponsedata.cpp
+++ b/libamqpprox/amqpprox_authresponsedata.cpp
@@ -1,0 +1,36 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_authresponsedata.h>
+
+#include <string_view>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+AuthResponseData::AuthResponseData(const AuthResult &authResult,
+                                   std::string_view  reason,
+                                   std::string_view  authMechanism,
+                                   std::string_view  credentials)
+: d_authResult(authResult)
+, d_reason(reason)
+, d_authMechanism(authMechanism)
+, d_credentials(credentials)
+{
+}
+
+}
+}

--- a/libamqpprox/amqpprox_authresponsedata.h
+++ b/libamqpprox/amqpprox_authresponsedata.h
@@ -1,0 +1,105 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef BLOOMBERG_AMQPPROX_AUTHRESPONSEDATA
+#define BLOOMBERG_AMQPPROX_AUTHRESPONSEDATA
+
+#include <string>
+#include <string_view>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+/**
+ * \brief Provide a class to hold response data for authn/authz operations
+ */
+class AuthResponseData {
+  public:
+    /**
+     * The enum class will represents authn/authz result for specific auth
+     * client request for particular AMQP connection
+     */
+    enum class AuthResult { ALLOW, DENY };
+
+  private:
+    AuthResult  d_authResult;
+    std::string d_reason;
+    std::string d_authMechanism;
+    std::string d_credentials;
+
+  public:
+    /**
+     * \brief Create and initialize object of AuthResponseData class
+     * \param authResult represents authn/authz result for connecting AMQP
+     * client to proxy
+     * \param reason more detailed information related to auth result
+     * \param authMechanism authentication mechanism field for START-OK
+     * connection method
+     * \param credentials response field for START-OK connection method
+     */
+    explicit AuthResponseData(const AuthResult &authResult,
+                              std::string_view  reason        = "",
+                              std::string_view  authMechanism = "",
+                              std::string_view  credentials   = "");
+
+    /**
+     * \return authn/authz result for connecting AMQP client to proxy
+     */
+    inline const AuthResult getAuthResult() const;
+
+    /**
+     * \return more detailed information related to auth result
+     */
+    inline const std::string getReason() const;
+
+    /**
+     * \return authentication mechanism field for START-OK connection method.
+     * This field will be injected to START-OK connection method to send to the
+     * broker.
+     */
+    inline const std::string getAuthMechanism() const;
+
+    /**
+     * \return response field for START-OK connection method. This field will
+     * be injected to START-OK connection method to send to the broker.
+     */
+    inline const std::string getCredentials() const;
+};
+
+inline const AuthResponseData::AuthResult
+AuthResponseData::getAuthResult() const
+{
+    return d_authResult;
+}
+
+inline const std::string AuthResponseData::getReason() const
+{
+    return d_reason;
+}
+
+inline const std::string AuthResponseData::getAuthMechanism() const
+{
+    return d_authMechanism;
+}
+
+inline const std::string AuthResponseData::getCredentials() const
+{
+    return d_credentials;
+}
+
+}
+}
+
+#endif

--- a/libamqpprox/amqpprox_connectionstats.cpp
+++ b/libamqpprox/amqpprox_connectionstats.cpp
@@ -33,6 +33,7 @@ const std::vector<std::string> ConnectionStats::s_sessionMetrics = {
 const std::vector<std::string> ConnectionStats::s_statsTypes = {
     "pausedConnectionCount",
     "activeConnectionCount",
+    "authDeniedConnectionCount",
     "removedConnectionGraceful",
     "removedConnectionBrokerSnapped",
     "removedConnectionClientSnapped",

--- a/libamqpprox/amqpprox_connector.cpp
+++ b/libamqpprox/amqpprox_connector.cpp
@@ -298,9 +298,19 @@ void Connector::synthesizeCloseError(bool sendToIngressSide)
     synthesizeMessage<Reply::CloseOkExpected>(d_close, sendToIngressSide);
 }
 
+void Connector::synthesizeCloseAuthError(bool sendToIngressSide)
+{
+    synthesizeMessage<Reply::CloseAuthDeny>(d_close, sendToIngressSide);
+}
+
 Buffer Connector::outBuffer()
 {
     return d_buffer;
+}
+
+void Connector::resetOutBuffer()
+{
+    d_buffer = Buffer();
 }
 
 bool Connector::sendToIngressSide()
@@ -416,6 +426,24 @@ void Connector::synthesizeProxyProtocolHeader(
         Buffer(proxyProtocolHeader.data(), proxyProtocolHeader.size()));
 
     d_buffer = tempBuffer.currentData();
+}
+
+const FieldTable Connector::getClientProperties() const
+{
+    return d_startOk.properties();
+}
+
+const std::pair<std::string_view, std::string_view>
+Connector::getAuthMechanismCredentials() const
+{
+    return std::make_pair(d_startOk.mechanism(), d_startOk.response());
+}
+
+void Connector::setAuthMechanismCredentials(std::string_view authMechanism,
+                                            std::string_view credentials)
+{
+    d_startOk.setAuthMechanism(authMechanism);
+    d_startOk.setCredentials(credentials);
 }
 
 }

--- a/libamqpprox/amqpprox_connector.h
+++ b/libamqpprox/amqpprox_connector.h
@@ -18,6 +18,7 @@
 
 #include <amqpprox_buffer.h>
 #include <amqpprox_bufferhandle.h>
+#include <amqpprox_fieldtable.h>
 #include <amqpprox_flowtype.h>
 #include <amqpprox_method.h>
 #include <amqpprox_methods_close.h>
@@ -31,6 +32,7 @@
 
 #include <functional>
 #include <string_view>
+#include <utility>
 
 namespace Bloomberg {
 namespace amqpprox {
@@ -157,6 +159,14 @@ class Connector {
     void synthesizeCloseError(bool sendToIngressSide);
 
     /**
+     * \brief Send AMQP connection Close method with ERROR status to
+     * client/server based on specified direction
+     * \param sendToIngressSide true for communicating with client and false
+     * for communicating with server
+     */
+    void synthesizeCloseAuthError(bool sendToIngressSide);
+
+    /**
      * \brief Synthesize AMQP protocol header buffer, which will eventually be
      * sent to server(broker).
      */
@@ -174,9 +184,40 @@ class Connector {
     Buffer outBuffer();
 
     /**
+     * \brief Reset current buffer
+     */
+    void resetOutBuffer();
+
+    /**
      * \return the current direction of the data flow (ingree/egress)
      */
     bool sendToIngressSide();
+
+    /**
+     * \brief AMQP client sends client properties using START-OK connection
+     * method. The method extracts properties information from that method
+     * fields.
+     * \return client properties as a Fieldtable
+     */
+    const FieldTable getClientProperties() const;
+
+    /**
+     * \brief AMQP client sends auth mechansim and credential information using
+     * START-OK connection method. The method extracts mechanism and credential
+     * information from that method fields.
+     * \return pair of AMQP authentication mechanism, AMQP response field
+     */
+    const std::pair<std::string_view, std::string_view>
+    getAuthMechanismCredentials() const;
+
+    /**
+     * \brief Set different authentication mechanism and credentials for AMQP
+     * START-OK connection method, which will be sent to server for
+     * authentication and authorization \param authMechanism of AMQP
+     * authentication mechanism \param credentials data for AMQP response field
+     */
+    void setAuthMechanismCredentials(std::string_view authMechanism,
+                                     std::string_view credentials);
 };
 
 inline Connector::State Connector::state() const

--- a/libamqpprox/amqpprox_connectorutil.cpp
+++ b/libamqpprox/amqpprox_connectorutil.cpp
@@ -56,7 +56,7 @@ FieldTable ConnectorUtil::generateServerProperties()
                          "consumer_cancel_notify",
                          "connection.blocked",
                          "consumer_priorities",
-                         "authentication_failure_close",
+                         Constants::authenticationFailureClose(),
                          "per_consumer_qos",
                          "direct_reply_to"};
 
@@ -64,7 +64,8 @@ FieldTable ConnectorUtil::generateServerProperties()
         capabilitiesTable->pushField(cap, FieldValue('t', true));
     }
 
-    ft.pushField("capabilities", FieldValue('F', capabilitiesTable));
+    ft.pushField(Constants::capabilities(),
+                 FieldValue('F', capabilitiesTable));
     ft.pushField("cluster_name",
                  FieldValue('S', std::string(Constants::clusterName())));
     ft.pushField("copyright",

--- a/libamqpprox/amqpprox_constants.h
+++ b/libamqpprox/amqpprox_constants.h
@@ -90,6 +90,13 @@ class Constants {
     static constexpr const char *cr() { return "\r\n"; }
 
     static constexpr uint8_t frameEnd() { return 0xCE; }
+
+    static constexpr const char *capabilities() { return "capabilities"; }
+
+    static constexpr const char *authenticationFailureClose()
+    {
+        return "authentication_failure_close";
+    }
 };
 
 }

--- a/libamqpprox/amqpprox_defaultauthintercept.cpp
+++ b/libamqpprox/amqpprox_defaultauthintercept.cpp
@@ -1,0 +1,54 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_defaultauthintercept.h>
+
+#include <amqpprox_authinterceptinterface.h>
+#include <amqpprox_authrequestdata.h>
+#include <amqpprox_authresponsedata.h>
+
+#include <iostream>
+
+#include <boost/asio.hpp>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+DefaultAuthIntercept::DefaultAuthIntercept(boost::asio::io_service &ioService)
+: AuthInterceptInterface(ioService)
+{
+}
+
+void DefaultAuthIntercept::authenticate(const AuthRequestData,
+                                        const ReceiveResponseCb &responseCb)
+{
+    auto cb = [responseCb] {
+        AuthResponseData authResponseData(
+            AuthResponseData::AuthResult::ALLOW,
+            "Default route auth used - always allow");
+        responseCb(authResponseData);
+    };
+    boost::asio::post(d_ioService, cb);
+}
+
+void DefaultAuthIntercept::print(std::ostream &os) const
+{
+    os << "All connections are authorised to route to any vhost. No auth "
+          "service requests are made.\n";
+}
+
+}
+}

--- a/libamqpprox/amqpprox_defaultauthintercept.h
+++ b/libamqpprox/amqpprox_defaultauthintercept.h
@@ -1,0 +1,62 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef BLOOMBERG_AMQPPROX_DEFAULTAUTHINTERCEPT
+#define BLOOMBERG_AMQPPROX_DEFAULTAUTHINTERCEPT
+
+#include <amqpprox_authinterceptinterface.h>
+#include <amqpprox_authrequestdata.h>
+
+#include <iostream>
+
+#include <boost/asio.hpp>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+/**
+ * \brief Performs authn/authz operations for incoming clients, implements the
+ * AuthInterceptInterface interface
+ */
+class DefaultAuthIntercept : public AuthInterceptInterface {
+  public:
+    // CREATORS
+    explicit DefaultAuthIntercept(boost::asio::io_service &ioService);
+
+    virtual ~DefaultAuthIntercept() override = default;
+
+    // MANIPULATORS
+    /**
+     * \brief It gets all the information required to authenticate from client
+     * in authRequestData parameter and invoke callback function to provide
+     * response.
+     * \param authRequestData auth request data payload
+     * \param responseCb Callbak function with response values
+     */
+    virtual void authenticate(const AuthRequestData    authRequestData,
+                              const ReceiveResponseCb &responseCb) override;
+
+    // ACCESSORS
+    /**
+     * \brief Print information about route auth gate service
+     * \param os output stream object
+     */
+    virtual void print(std::ostream &os) const override;
+};
+
+}
+}
+
+#endif

--- a/libamqpprox/amqpprox_humanstatformatter.cpp
+++ b/libamqpprox/amqpprox_humanstatformatter.cpp
@@ -53,6 +53,8 @@ void HumanStatFormatter::format(std::ostream &os, const ConnectionStats &stats)
 {
     os << "Paused: " << stats.statsValue("pausedConnectionCount") << " "
        << "Active: " << stats.statsValue("activeConnectionCount") << " "
+       << "Auth denied: " << stats.statsValue("authDeniedConnectionCount")
+       << " "
        << "Removed(Clean): " << stats.statsValue("removedConnectionGraceful")
        << " "
        << "Removed(Broker): "

--- a/libamqpprox/amqpprox_jsonstatformatter.cpp
+++ b/libamqpprox/amqpprox_jsonstatformatter.cpp
@@ -28,6 +28,8 @@ void JsonStatFormatter::format(std::ostream &os, const ConnectionStats &stats)
        << stats.statsValue("pausedConnectionCount") << ", "
        << "\"activeConnectionCount\": "
        << stats.statsValue("activeConnectionCount") << ", "
+       << "\"authDeniedConnectionCount\": "
+       << stats.statsValue("authDeniedConnectionCount") << ", "
        << "\"removedConnectionGraceful\": "
        << stats.statsValue("removedConnectionGraceful") << ", "
        << "\"removedConnectionBrokerSnapped\": "

--- a/libamqpprox/amqpprox_methods_startok.cpp
+++ b/libamqpprox/amqpprox_methods_startok.cpp
@@ -18,6 +18,7 @@
 #include <amqpprox_types.h>
 
 #include <iostream>
+#include <string_view>
 
 namespace Bloomberg {
 namespace amqpprox {
@@ -37,6 +38,21 @@ bool StartOk::encode(Buffer &buffer, const StartOk &startOk)
            Types::encodeShortString(buffer, startOk.d_mechanism) &&
            Types::encodeLongString(buffer, startOk.d_response) &&
            Types::encodeShortString(buffer, startOk.d_locale);
+}
+
+void StartOk::setClientProperties(const FieldTable &clientProperties)
+{
+    d_properties = clientProperties;
+}
+
+void StartOk::setAuthMechanism(std::string_view authMechanism)
+{
+    d_mechanism = authMechanism;
+}
+
+void StartOk::setCredentials(std::string_view credentials)
+{
+    d_response = credentials;
 }
 
 std::ostream &operator<<(std::ostream &os, const StartOk &okMethod)

--- a/libamqpprox/amqpprox_methods_startok.h
+++ b/libamqpprox/amqpprox_methods_startok.h
@@ -21,6 +21,7 @@
 #include <boost/endian/arithmetic.hpp>
 #include <iosfwd>
 #include <string>
+#include <string_view>
 
 namespace Bloomberg {
 namespace amqpprox {
@@ -62,6 +63,24 @@ class StartOk {
     constexpr inline static int classType() { return 10; }
 
     constexpr inline static int methodType() { return 11; }
+
+    /**
+     * \brief Set specified AMQP client properties
+     * \param clientProperties AMQP client properties
+     */
+    void setClientProperties(const FieldTable &clientProperties);
+
+    /**
+     * \brief Set specified AMQP authMechanism
+     * \param authMechanism AMQP authentication mechanism
+     */
+    void setAuthMechanism(std::string_view authMechanism);
+
+    /**
+     * \brief Set specified AMQP response credentials
+     * \param credentials AMQP opaque credential data
+     */
+    void setCredentials(std::string_view credentials);
 };
 
 std::ostream &operator<<(std::ostream &os, const StartOk &okMethod);

--- a/libamqpprox/amqpprox_reply.h
+++ b/libamqpprox/amqpprox_reply.h
@@ -55,6 +55,12 @@ struct OK {
     constexpr static const char *const TEXT = "OK";
 };
 
+struct CloseAuthDeny {
+    constexpr static const uint16_t    CODE = Codes::access_refused;
+    constexpr static const char *const TEXT =
+        "ERROR: Not authorized by amqpprox proxy";
+};
+
 struct CloseOkExpected {
     constexpr static const uint16_t    CODE = Codes::channel_error;
     constexpr static const char *const TEXT = "ERROR: Expected CloseOk reply";

--- a/libamqpprox/amqpprox_server.cpp
+++ b/libamqpprox/amqpprox_server.cpp
@@ -16,6 +16,7 @@
 #include <amqpprox_server.h>
 
 #include <amqpprox_bufferpool.h>
+#include <amqpprox_defaultauthintercept.h>
 #include <amqpprox_eventsource.h>
 #include <amqpprox_hostnamemapper.h>
 #include <amqpprox_logging.h>
@@ -72,6 +73,7 @@ Server::Server(ConnectionSelector *selector,
 , d_mutex()
 , d_hostnameMapper()
 , d_localHostname(boost::asio::ip::host_name())
+, d_authIntercept(std::make_shared<DefaultAuthIntercept>(d_ioService))
 {
     d_dnsResolver.setCacheTimeout(1000);
     d_dnsResolver.startCleanupTimer();
@@ -210,7 +212,8 @@ void Server::doAccept(int port, bool secure)
                                               d_bufferPool_p,
                                               &d_dnsResolver,
                                               d_hostnameMapper,
-                                              d_localHostname);
+                                              d_localHostname,
+                                              d_authIntercept);
 
                 {
                     std::lock_guard<std::mutex> lg(d_mutex);

--- a/libamqpprox/amqpprox_server.h
+++ b/libamqpprox/amqpprox_server.h
@@ -16,6 +16,7 @@
 #ifndef BLOOMBERG_AMQPPROX_SERVER
 #define BLOOMBERG_AMQPPROX_SERVER
 
+#include <amqpprox_authinterceptinterface.h>
 #include <amqpprox_connectionselector.h>
 #include <amqpprox_dnsresolver.h>
 #include <amqpprox_maybesecuresocketadaptor.h>
@@ -58,6 +59,7 @@ class Server {
     std::mutex                      d_mutex;
     std::shared_ptr<HostnameMapper> d_hostnameMapper;
     std::string                     d_localHostname;
+    std::shared_ptr<AuthInterceptInterface> d_authIntercept;
 
   public:
     Server(ConnectionSelector *selector,

--- a/libamqpprox/amqpprox_sessionstate.cpp
+++ b/libamqpprox/amqpprox_sessionstate.cpp
@@ -44,6 +44,7 @@ SessionState::SessionState(
 , d_egressLatencyTotal(0)
 , d_egressLatencyCount(0)
 , d_paused(false)
+, d_authDeniedConnection(false)
 , d_virtualHost()
 , d_disconnectedStatus(DisconnectType::NOT_DISCONNECTED)
 , d_id(s_nextId++)  // This isn't a race because this is only on one thread
@@ -103,6 +104,11 @@ void SessionState::setHostnameMapper(
 void SessionState::setPaused(bool paused)
 {
     d_paused = paused;
+}
+
+void SessionState::setAuthDeniedConnection(bool authDenied)
+{
+    d_authDeniedConnection = authDenied;
 }
 
 void SessionState::setDisconnected(SessionState::DisconnectType disconnect)
@@ -196,6 +202,7 @@ std::ostream &operator<<(std::ostream &os, const SessionState &state)
                ? ""
                : "D")
        << (state.getPaused() ? "P " : " ")
+       << (state.getAuthDeniedConnection() ? "DENY " : " ")
        << state.hostname(state.getIngress().second) << ":"
        << state.getIngress().second.port() << "->"
        << state.hostname(state.getIngress().first) << " --> "

--- a/libamqpprox/amqpprox_sessionstate.h
+++ b/libamqpprox/amqpprox_sessionstate.h
@@ -59,6 +59,7 @@ class SessionState {
     std::atomic<uint64_t>           d_ingressLatencyTotal;
     std::atomic<uint64_t>           d_egressLatencyTotal;
     std::atomic<bool>               d_paused;
+    std::atomic<bool>               d_authDeniedConnection;
     std::string                     d_virtualHost;
     DisconnectType                  d_disconnectedStatus;
     uint64_t                        d_id;
@@ -106,6 +107,13 @@ class SessionState {
      * \param paused flag to specify paused or unpaused virtual host
      */
     void setPaused(bool paused);
+
+    /**
+     * \brief Set the denied connection flag, because of auth failure
+     * \param authDenied flag to specify denied connection because of auth
+     * failure
+     */
+    void setAuthDeniedConnection(bool authDenied);
 
     /**
      * \brief Set session as disconnected, along with which type of disconnect
@@ -176,6 +184,12 @@ class SessionState {
     inline bool getPaused() const;
 
     /**
+     * \return the state of the connection, whether it is denied because of
+     * auth failure
+     */
+    inline bool getAuthDeniedConnection() const;
+
+    /**
      * \return session identifier
      */
     inline uint64_t id() const;
@@ -221,6 +235,11 @@ inline const std::string &SessionState::getVirtualHost() const
 inline bool SessionState::getPaused() const
 {
     return d_paused;
+}
+
+inline bool SessionState::getAuthDeniedConnection() const
+{
+    return d_authDeniedConnection;
 }
 
 inline uint64_t SessionState::id() const

--- a/libamqpprox/amqpprox_statcollector.cpp
+++ b/libamqpprox/amqpprox_statcollector.cpp
@@ -127,6 +127,11 @@ void StatCollector::collect(const SessionState &session)
         if (session.getPaused()) {
             statsObject.statsValue("pausedConnectionCount") += 1;
         }
+
+        // Maintains total denied connections because of auth failure
+        if (session.getAuthDeniedConnection()) {
+            statsObject.statsValue("authDeniedConnectionCount") += 1;
+        }
     };
 
     addStats(vhostStats);

--- a/libamqpprox/amqpprox_statsdpublisher.cpp
+++ b/libamqpprox/amqpprox_statsdpublisher.cpp
@@ -87,7 +87,9 @@ void StatsDPublisher::publish(const ConnectionStats &stats,
                               const TagVector &      tags)
 {
     static const std::vector<std::string> gaugeMetrics = {
-        "pausedConnectionCount", "activeConnectionCount"};
+        "pausedConnectionCount",
+        "activeConnectionCount",
+        "authDeniedConnectionCount"};
     for (auto &name : ConnectionStats::statsTypes()) {
         MetricType type = MetricType::COUNTER;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,8 @@ add_executable(amqpprox_tests
     amqpprox_statcollector.t.cpp
     amqpprox_statsnapshot.t.cpp
     amqpprox_types.t.cpp
-    amqpprox_vhoststate.t.cpp)
+    amqpprox_vhoststate.t.cpp
+    amqpprox_defaultauthintercept.t.cpp)
 
 target_link_libraries(amqpprox_tests LINK_PUBLIC
     libamqpprox

--- a/tests/amqpprox_defaultauthintercept.t.cpp
+++ b/tests/amqpprox_defaultauthintercept.t.cpp
@@ -1,0 +1,64 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_defaultauthintercept.h>
+
+#include <amqpprox_authrequestdata.h>
+#include <amqpprox_authresponsedata.h>
+
+#include <gmock/gmock.h>
+
+#include <iostream>
+
+#include <boost/asio.hpp>
+
+using Bloomberg::amqpprox::AuthInterceptInterface;
+using Bloomberg::amqpprox::AuthRequestData;
+using Bloomberg::amqpprox::AuthResponseData;
+using Bloomberg::amqpprox::DefaultAuthIntercept;
+
+TEST(DefaultAuthIntercept, Breathing)
+{
+    boost::asio::io_service ioService;
+    DefaultAuthIntercept    defaultAuth(ioService);
+    ioService.run();
+}
+
+TEST(DefaultAuthIntercept, Authenticate)
+{
+    boost::asio::io_service ioService;
+    DefaultAuthIntercept    defaultAuth(ioService);
+    auto responseCb = [](const AuthResponseData &authResponseData) {
+        ASSERT_EQ(authResponseData.getAuthResult(),
+                  AuthResponseData::AuthResult::ALLOW);
+        ASSERT_EQ(authResponseData.getReason(),
+                  "Default route auth used - always allow");
+    };
+    defaultAuth.authenticate(AuthRequestData(), responseCb);
+    ioService.run();
+}
+
+TEST(DefaultAuthIntercept, Print)
+{
+    boost::asio::io_service ioService;
+    DefaultAuthIntercept    defaultAuth(ioService);
+    ioService.run();
+    std::ostringstream oss;
+    defaultAuth.print(oss);
+    EXPECT_EQ(oss.str(),
+              "All connections are authorised to route to any vhost. No auth "
+              "service requests are made.\n");
+}

--- a/tests/amqpprox_statcollector.t.cpp
+++ b/tests/amqpprox_statcollector.t.cpp
@@ -81,6 +81,7 @@ TEST(StatCollector, Simple_Single_Session)
     ConnectionStats expectedStats(
         {{"pausedConnectionCount", 0},
          {"activeConnectionCount", 1},
+         {"authDeniedConnectionCount", 0},
          {"removedConnectionGraceful", 0},
          {"removedConnectionBrokerSnapped", 0},
          {"removedConnectionClientSnapped", 0},
@@ -126,6 +127,7 @@ TEST(StatCollector, Multiple_Session)
     state3.incrementIngressTotals(3000, 4000);
     state3.addIngressLatency(2);
     state3.setPaused(true);
+    state3.setAuthDeniedConnection(true);
 
     StatCollector sc;
     sc.collect(state1);
@@ -135,6 +137,7 @@ TEST(StatCollector, Multiple_Session)
     ConnectionStats expectedStats(
         {{"pausedConnectionCount", 1},
          {"activeConnectionCount", 3},
+         {"authDeniedConnectionCount", 1},
          {"removedConnectionGraceful", 0},
          {"removedConnectionBrokerSnapped", 0},
          {"removedConnectionClientSnapped", 0},
@@ -152,6 +155,7 @@ TEST(StatCollector, Multiple_Session)
     ConnectionStats expectedFooStats(
         {{"pausedConnectionCount", 0},
          {"activeConnectionCount", 2},
+         {"authDeniedConnectionCount", 0},
          {"removedConnectionGraceful", 0},
          {"removedConnectionBrokerSnapped", 0},
          {"removedConnectionClientSnapped", 0},
@@ -166,6 +170,7 @@ TEST(StatCollector, Multiple_Session)
     ConnectionStats expectedBarStats(
         {{"pausedConnectionCount", 1},
          {"activeConnectionCount", 1},
+         {"authDeniedConnectionCount", 1},
          {"removedConnectionGraceful", 0},
          {"removedConnectionBrokerSnapped", 0},
          {"removedConnectionClientSnapped", 0},
@@ -219,6 +224,7 @@ TEST(StatCollector, Returns_To_Zero)
     ConnectionStats expectedStats(
         {{"pausedConnectionCount", 0},
          {"activeConnectionCount", 1},
+         {"authDeniedConnectionCount", 0},
          {"removedConnectionGraceful", 0},
          {"removedConnectionBrokerSnapped", 0},
          {"removedConnectionClientSnapped", 0},
@@ -261,6 +267,7 @@ TEST(StatCollector, Handles_New_Counter_Values)
     ConnectionStats expectedStats(
         {{"pausedConnectionCount", 0},
          {"activeConnectionCount", 1},
+         {"authDeniedConnectionCount", 0},
          {"removedConnectionGraceful", 0},
          {"removedConnectionBrokerSnapped", 0},
          {"removedConnectionClientSnapped", 0},

--- a/tests/amqpprox_testsocketstate.cpp
+++ b/tests/amqpprox_testsocketstate.cpp
@@ -63,8 +63,8 @@ bool TestSocketState::drive()
     bool  didWork = false;
 
     for (; step.d_produceIndex < sz; ++step.d_produceIndex) {
-        auto item           = &step.d_produce[step.d_produceIndex];
-        didWork = true;
+        auto item = &step.d_produce[step.d_produceIndex];
+        didWork   = true;
 
         if (auto state = std::get_if<State>(item)) {
             d_currentState = *state;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: RDSIRABBIT-1962*

**Introducing auth gate service interface**
Auth gate service will be used to authn/authz each client connection during initial handshake. This service can be any external http service. This PR only contains interface to communicate with that external http service and default implementation of the interface. The default implementation will always allow all the clients to connect without any authn/authz. The PR also contains unit tests for default implementation of the interface. Currently we are going to target similar authn/authz mechanism for entire server level. The second PR will contain the http implementation of the interface, in which all the clients will be authn/authz using external http service and control command to configure http service parameters like hostname, port, target. The auth service will get vhost, auth mechanism and credentials information from amqpprox for connecting AMQP client.  And the service will return allow/deny with reason, auth mechanism and credentials information after processing the request.  The returned credential information will be forwarded to server/broker to finally connect.

In case of, unauthorized connection, the proxy will close client connection based on `authentication_failure_close` capabilities defined in client properties, received from client. If that value is true, then proxy will send the close connection method before snapping socket connection. For example, pika client will receive an error like `pika.exceptions.ProbableAccessDeniedError: ConnectionClosedByBroker: (403) 'ERROR: Not authorized by amqpprox proxy'`. But if that value is false, then proxy will snap the socket connection without sending any close connection method. For example, pika client will receive an error like `pika.exceptions.ProbableAccessDeniedError: StreamLostError: ('Transport indicated EOF',)`

**What testing happened**
This PR introduces unit tests for the default implementation of the auth interface component. The PR also modifies session tests to incorporate usage of auth interface and change the behaviour based on allowed or denied auth request.