### PR TITLE
use a CUR_DIR variable and get rid of realpath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 UNAME_OVERRIDE ?= `uname`
 BUILD_PARALLELISM ?= `nproc`
 BUILDDIR ?= build/$(UNAME_OVERRIDE)
+CUR_DIR ?= $(shell pwd)
 
 test:
 	cd $(BUILDDIR) && make -j$(BUILD_PARALLELISM)
@@ -13,17 +14,17 @@ setup: BUILD_FLAVOUR ?= conan
 setup:
 	mkdir -p $(BUILDDIR)
 	/bin/echo -n "$(BUILD_FLAVOUR)" > $(BUILDDIR)/flavour
-	(test -x ./buildfiles/$(BUILD_FLAVOUR)/bootstrap && ./buildfiles/$(BUILD_FLAVOUR)/bootstrap $(BUILDDIR) $(realpath .)) || true
+	(test -x ./buildfiles/$(BUILD_FLAVOUR)/bootstrap && ./buildfiles/$(BUILD_FLAVOUR)/bootstrap $(BUILDDIR) $(CUR_DIR)) || true
 
 init:
-	cd $(BUILDDIR) && cmake $(EXTRA_CMAKE_ARGS) $(shell pwd)
+	cd $(BUILDDIR) && cmake $(EXTRA_CMAKE_ARGS) $(CUR_DIR)
 
 clean:
 	cd $(BUILDDIR) && make clean
 
 DOCKER_IMAGE ?= amqpprox
 DOCKER_BUILDDIR ?= build/docker-$(DOCKER_IMAGE)
-DOCKER_ARGS ?= $(DOCKER_EXTRA_ARGS) -v $(shell pwd):/source -v $(shell realpath $(DOCKER_BUILDDIR)):/build -it $(DOCKER_IMAGE)
+DOCKER_ARGS ?= $(DOCKER_EXTRA_ARGS) -v $(CUR_DIR):/source -v $(CUR_DIR)/$(DOCKER_BUILDDIR):/build -it $(DOCKER_IMAGE)
 DOCKER_RUN ?= docker run $(DOCKER_ARGS)
 
 docker-setup: BUILD_FLAVOUR ?= conan

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ We only recommend using Linux based operating systems for running amqpprox;
 however, we also regularly develop it on Mac OS and expect changes to not break
 the native build there.
 
+By default the build doesn't contain debug symbols, for Debug one can make use of the 
+`CMAKE_EXTRA_ARGS='-DCMAKE_BUILD_TYPE=Debug'` environment, for Release optimisations 
+one can set this to `CMAKE_EXTRA_ARGS='-DCMAKE_BUILD_TYPE=Release'` 
+
 ## Installation
 
 //TODO

--- a/buildfiles/README.md
+++ b/buildfiles/README.md
@@ -30,6 +30,7 @@ Overall:
 
 - `BUILD_FLAVOUR`: Used at setup time to select which set of buildfiles to be
     used. Selects a sub-directory of the buildfiles directory.
+- `CUR_DIR`: The directory of the makefile (defaults to `pwd`)
 
 For native builds:
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
the realpath script doesn't work straight out of the box on mac, so removing this in favour of setting a `CUR_DIR` variable which defaults to the output of `pwd`

**Testing performed**
make setup
make docker-setup

