### PR TITLE
Change copyright year for remaining files

### DIFF
--- a/amqpprox/amqpprox.m.cpp
+++ b/amqpprox/amqpprox.m.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -77,7 +77,6 @@ Although most configuration is injected by the amqpprox_ctl program, the logging
 )helptext";
 }
 
-
 int main(int argc, char *argv[])
 {
     using namespace std::string_literals;
@@ -95,29 +94,62 @@ int main(int argc, char *argv[])
     // Set up the basic command line options to allow multiple instances to run
     // on a single box without colliding
     po::options_description options(HELP_TEXT);
-    options.add_options()("help", "This help information")(
-        "logDirectory",
-        po::value<std::string>(&logDirectory)->default_value("logs"),
-        "Set logging directory")(
-        "controlSocket",
-        po::value<std::string>(&controlSocket)->default_value("/tmp/amqpprox"),
-        "Set control UNIX domain socket location")(
-        "cleanupIntervalMs",
-        po::value<uint32_t>(&cleanupIntervalMs)->default_value(1000u),
-        "Set the cleanup interval to garbage collect connections")(
-        "listenPort",
-        po::value<uint16_t>(&easyListenPort)->default_value(0),
-        "Simple config mode: listening port")(
-        "destinationPort",
-        po::value<uint16_t>(&easyDestinationPort)->default_value(0),
-        "Simple config mode: destination port")(
-        "destinationDNS",
-        po::value<std::string>(&easyDestinationDNS)->default_value(""),
-        "Simple config mode: destination DNS address")(
-        "consoleVerbosity,v",
-        po::value<uint16_t>(&consoleVerbosity)->default_value(0),
-        "Default console logging verbosity (0 = No output through to 5 = "
-        "Trace-level)");
+    options
+        .add_options()("help", "This help information")(
+            "logDirectory",
+            po::value<std::string>(&logDirectory)->default_value("logs"),
+            "Set logging directory")("controlSocket",
+                                     po::value<std::string>(&controlSocket)
+                                         ->default_value("/tmp/amqpprox"),
+                                     "Set control UNIX domain socket "
+                                     "location")("cleanupIntervalMs",
+                                                 po::value<uint32_t>(
+                                                     &cleanupIntervalMs)
+                                                     ->default_value(1000u),
+                                                 "Set the cleanup interval to "
+                                                 "garbage collect "
+                                                 "connections")("listenPort",
+                                                                po::value<
+                                                                    uint16_t>(
+                                                                    &easyListenPort)
+                                                                    ->default_value(
+                                                                        0),
+                                                                "Simple "
+                                                                "config mode: "
+                                                                "listening "
+                                                                "port")("desti"
+                                                                        "natio"
+                                                                        "nPor"
+                                                                        "t",
+                                                                        po::value<
+                                                                            uint16_t>(
+                                                                            &easyDestinationPort)
+                                                                            ->default_value(
+                                                                                0),
+                                                                        "Simpl"
+                                                                        "e "
+                                                                        "confi"
+                                                                        "g "
+                                                                        "mode:"
+                                                                        " dest"
+                                                                        "inati"
+                                                                        "on "
+                                                                        "por"
+                                                                        "t")("destinationDNS",
+                                                                             po::value<
+                                                                                 std::
+                                                                                     string>(
+                                                                                 &easyDestinationDNS)
+                                                                                 ->default_value(
+                                                                                     ""),
+                                                                             "Simple config mode: destination DNS address")("consoleVerbosity,v",
+                                                                                                                            po::value<
+                                                                                                                                uint16_t>(
+                                                                                                                                &consoleVerbosity)
+                                                                                                                                ->default_value(
+                                                                                                                                    0),
+                                                                                                                            "Default console logging verbosity (0 = No output through to 5 = "
+                                                                                                                            "Trace-level)");
 
     po::variables_map variablesMap;
 

--- a/amqpprox_ctl/client.m.cpp
+++ b/amqpprox_ctl/client.m.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_affinitypartitionpolicy.cpp
+++ b/libamqpprox/amqpprox_affinitypartitionpolicy.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_affinitypartitionpolicy.h
+++ b/libamqpprox/amqpprox_affinitypartitionpolicy.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backend.cpp
+++ b/libamqpprox/amqpprox_backend.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backend.h
+++ b/libamqpprox/amqpprox_backend.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class Backend {
     inline const std::string &name() const;
     inline bool               proxyProtocolEnabled() const;
     inline bool               tlsEnabled() const;
-    inline bool               dnsBasedEntry() const;  
+    inline bool               dnsBasedEntry() const;
 };
 
 inline const std::string &Backend::host() const

--- a/libamqpprox/amqpprox_backendcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_backendcontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendcontrolcommand.h
+++ b/libamqpprox/amqpprox_backendcontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendselector.cpp
+++ b/libamqpprox/amqpprox_backendselector.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendselector.h
+++ b/libamqpprox/amqpprox_backendselector.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendselectorstore.cpp
+++ b/libamqpprox/amqpprox_backendselectorstore.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendselectorstore.h
+++ b/libamqpprox/amqpprox_backendselectorstore.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendset.cpp
+++ b/libamqpprox/amqpprox_backendset.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendset.h
+++ b/libamqpprox/amqpprox_backendset.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendstore.cpp
+++ b/libamqpprox/amqpprox_backendstore.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_backendstore.h
+++ b/libamqpprox/amqpprox_backendstore.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_buffer.cpp
+++ b/libamqpprox/amqpprox_buffer.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_buffer.h
+++ b/libamqpprox/amqpprox_buffer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_bufferhandle.cpp
+++ b/libamqpprox/amqpprox_bufferhandle.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_bufferhandle.h
+++ b/libamqpprox/amqpprox_bufferhandle.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_bufferpool.cpp
+++ b/libamqpprox/amqpprox_bufferpool.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_bufferpool.h
+++ b/libamqpprox/amqpprox_bufferpool.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_buffersource.cpp
+++ b/libamqpprox/amqpprox_buffersource.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_buffersource.h
+++ b/libamqpprox/amqpprox_buffersource.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectionmanager.cpp
+++ b/libamqpprox/amqpprox_connectionmanager.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectionmanager.h
+++ b/libamqpprox/amqpprox_connectionmanager.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectionscontrolcommand.cpp
+++ b/libamqpprox/amqpprox_connectionscontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectionscontrolcommand.h
+++ b/libamqpprox/amqpprox_connectionscontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectionselector.cpp
+++ b/libamqpprox/amqpprox_connectionselector.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectionselector.h
+++ b/libamqpprox/amqpprox_connectionselector.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectionstats.cpp
+++ b/libamqpprox/amqpprox_connectionstats.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectionstats.h
+++ b/libamqpprox/amqpprox_connectionstats.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connector.cpp
+++ b/libamqpprox/amqpprox_connector.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connector.h
+++ b/libamqpprox/amqpprox_connector.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectorutil.cpp
+++ b/libamqpprox/amqpprox_connectorutil.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_connectorutil.h
+++ b/libamqpprox/amqpprox_connectorutil.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_constants.cpp
+++ b/libamqpprox/amqpprox_constants.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_control.cpp
+++ b/libamqpprox/amqpprox_control.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_control.h
+++ b/libamqpprox/amqpprox_control.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_controlcommand.cpp
+++ b/libamqpprox/amqpprox_controlcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_controlcommand.h
+++ b/libamqpprox/amqpprox_controlcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_cpumonitor.cpp
+++ b/libamqpprox/amqpprox_cpumonitor.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_cpumonitor.h
+++ b/libamqpprox/amqpprox_cpumonitor.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_datacenter.cpp
+++ b/libamqpprox/amqpprox_datacenter.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_datacenter.h
+++ b/libamqpprox/amqpprox_datacenter.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_datacentercontrolcommand.cpp
+++ b/libamqpprox/amqpprox_datacentercontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_datacentercontrolcommand.h
+++ b/libamqpprox/amqpprox_datacentercontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_dnshostnamemapper.cpp
+++ b/libamqpprox/amqpprox_dnshostnamemapper.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_dnshostnamemapper.h
+++ b/libamqpprox/amqpprox_dnshostnamemapper.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_eventsource.cpp
+++ b/libamqpprox/amqpprox_eventsource.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_eventsource.h
+++ b/libamqpprox/amqpprox_eventsource.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_eventsourcesignal.cpp
+++ b/libamqpprox/amqpprox_eventsourcesignal.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_eventsourcesignal.h
+++ b/libamqpprox/amqpprox_eventsourcesignal.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_exitcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_exitcontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_exitcontrolcommand.h
+++ b/libamqpprox/amqpprox_exitcontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_farm.cpp
+++ b/libamqpprox/amqpprox_farm.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_farm.h
+++ b/libamqpprox/amqpprox_farm.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_farmcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_farmcontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_farmcontrolcommand.h
+++ b/libamqpprox/amqpprox_farmcontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_farmstore.cpp
+++ b/libamqpprox/amqpprox_farmstore.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_farmstore.h
+++ b/libamqpprox/amqpprox_farmstore.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_fieldtable.cpp
+++ b/libamqpprox/amqpprox_fieldtable.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_fieldtable.h
+++ b/libamqpprox/amqpprox_fieldtable.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_fieldvalue.cpp
+++ b/libamqpprox/amqpprox_fieldvalue.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_fieldvalue.h
+++ b/libamqpprox/amqpprox_fieldvalue.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_flowtype.cpp
+++ b/libamqpprox/amqpprox_flowtype.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_flowtype.h
+++ b/libamqpprox/amqpprox_flowtype.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_frame.cpp
+++ b/libamqpprox/amqpprox_frame.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_frame.h
+++ b/libamqpprox/amqpprox_frame.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_helpcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_helpcontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_helpcontrolcommand.h
+++ b/libamqpprox/amqpprox_helpcontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_hostnamemapper.cpp
+++ b/libamqpprox/amqpprox_hostnamemapper.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_hostnamemapper.h
+++ b/libamqpprox/amqpprox_hostnamemapper.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_humanstatformatter.cpp
+++ b/libamqpprox/amqpprox_humanstatformatter.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_humanstatformatter.h
+++ b/libamqpprox/amqpprox_humanstatformatter.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_jsonstatformatter.cpp
+++ b/libamqpprox/amqpprox_jsonstatformatter.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_jsonstatformatter.h
+++ b/libamqpprox/amqpprox_jsonstatformatter.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_listencontrolcommand.cpp
+++ b/libamqpprox/amqpprox_listencontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_listencontrolcommand.h
+++ b/libamqpprox/amqpprox_listencontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_logging.cpp
+++ b/libamqpprox/amqpprox_logging.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_logging.h
+++ b/libamqpprox/amqpprox_logging.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_loggingcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_loggingcontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_loggingcontrolcommand.h
+++ b/libamqpprox/amqpprox_loggingcontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_mapcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_mapcontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_mapcontrolcommand.h
+++ b/libamqpprox/amqpprox_mapcontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_maphostnamecontrolcommand.cpp
+++ b/libamqpprox/amqpprox_maphostnamecontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_maphostnamecontrolcommand.h
+++ b/libamqpprox/amqpprox_maphostnamecontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_mappingconnectionselector.cpp
+++ b/libamqpprox/amqpprox_mappingconnectionselector.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_mappingconnectionselector.h
+++ b/libamqpprox/amqpprox_mappingconnectionselector.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_maybesecuresocketadaptor.cpp
+++ b/libamqpprox/amqpprox_maybesecuresocketadaptor.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_maybesecuresocketadaptor.h
+++ b/libamqpprox/amqpprox_maybesecuresocketadaptor.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_method.cpp
+++ b/libamqpprox/amqpprox_method.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_method.h
+++ b/libamqpprox/amqpprox_method.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_close.cpp
+++ b/libamqpprox/amqpprox_methods_close.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_close.h
+++ b/libamqpprox/amqpprox_methods_close.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_closeok.cpp
+++ b/libamqpprox/amqpprox_methods_closeok.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_closeok.h
+++ b/libamqpprox/amqpprox_methods_closeok.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_open.cpp
+++ b/libamqpprox/amqpprox_methods_open.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_open.h
+++ b/libamqpprox/amqpprox_methods_open.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_openok.cpp
+++ b/libamqpprox/amqpprox_methods_openok.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_openok.h
+++ b/libamqpprox/amqpprox_methods_openok.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_secure.cpp
+++ b/libamqpprox/amqpprox_methods_secure.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_secure.h
+++ b/libamqpprox/amqpprox_methods_secure.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_secureok.cpp
+++ b/libamqpprox/amqpprox_methods_secureok.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_secureok.h
+++ b/libamqpprox/amqpprox_methods_secureok.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_start.cpp
+++ b/libamqpprox/amqpprox_methods_start.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_start.h
+++ b/libamqpprox/amqpprox_methods_start.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_startok.cpp
+++ b/libamqpprox/amqpprox_methods_startok.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_startok.h
+++ b/libamqpprox/amqpprox_methods_startok.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_tune.cpp
+++ b/libamqpprox/amqpprox_methods_tune.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_tune.h
+++ b/libamqpprox/amqpprox_methods_tune.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_tuneok.cpp
+++ b/libamqpprox/amqpprox_methods_tuneok.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_methods_tuneok.h
+++ b/libamqpprox/amqpprox_methods_tuneok.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_packetprocessor.cpp
+++ b/libamqpprox/amqpprox_packetprocessor.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -56,8 +56,7 @@ void PacketProcessor::process(FlowType direction, const Buffer &readBuffer)
             LOG_DEBUG << "Haven't quite read enough for full protocol header: "
                       << remaining;
 
-            d_remainingBuffer =
-                Buffer(readBuffer.originalPtr(), remaining);
+            d_remainingBuffer = Buffer(readBuffer.originalPtr(), remaining);
             return;
         }
 

--- a/libamqpprox/amqpprox_packetprocessor.h
+++ b/libamqpprox/amqpprox_packetprocessor.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 #ifndef BLOOMBERG_AMQPPROX_PROCESS
 #define BLOOMBERG_AMQPPROX_PROCESS
 
-#include <amqpprox_flowtype.h>
 #include <amqpprox_buffer.h>
+#include <amqpprox_flowtype.h>
 
 #include <cstddef>
 

--- a/libamqpprox/amqpprox_partitionpolicy.cpp
+++ b/libamqpprox/amqpprox_partitionpolicy.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_partitionpolicy.h
+++ b/libamqpprox/amqpprox_partitionpolicy.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_partitionpolicystore.cpp
+++ b/libamqpprox/amqpprox_partitionpolicystore.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_partitionpolicystore.h
+++ b/libamqpprox/amqpprox_partitionpolicystore.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_proxyprotocolheaderv1.cpp
+++ b/libamqpprox/amqpprox_proxyprotocolheaderv1.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_proxyprotocolheaderv1.h
+++ b/libamqpprox/amqpprox_proxyprotocolheaderv1.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_reply.cpp
+++ b/libamqpprox/amqpprox_reply.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -17,4 +17,3 @@
 #include <amqpprox_reply.h>
 
 // Ensure builds independently
-

--- a/libamqpprox/amqpprox_reply.h
+++ b/libamqpprox/amqpprox_reply.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_resourcemapper.cpp
+++ b/libamqpprox/amqpprox_resourcemapper.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_resourcemapper.h
+++ b/libamqpprox/amqpprox_resourcemapper.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_robinbackendselector.cpp
+++ b/libamqpprox/amqpprox_robinbackendselector.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_robinbackendselector.h
+++ b/libamqpprox/amqpprox_robinbackendselector.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_server.cpp
+++ b/libamqpprox/amqpprox_server.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_server.h
+++ b/libamqpprox/amqpprox_server.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_serverutil.cpp
+++ b/libamqpprox/amqpprox_serverutil.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_serverutil.h
+++ b/libamqpprox/amqpprox_serverutil.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_sessioncleanup.cpp
+++ b/libamqpprox/amqpprox_sessioncleanup.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_sessioncleanup.h
+++ b/libamqpprox/amqpprox_sessioncleanup.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_sessioncontrolcommand.cpp
+++ b/libamqpprox/amqpprox_sessioncontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_sessioncontrolcommand.h
+++ b/libamqpprox/amqpprox_sessioncontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_sessionstate.cpp
+++ b/libamqpprox/amqpprox_sessionstate.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_sessionstate.h
+++ b/libamqpprox/amqpprox_sessionstate.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_simpleconnectionselector.cpp
+++ b/libamqpprox/amqpprox_simpleconnectionselector.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_simpleconnectionselector.h
+++ b/libamqpprox/amqpprox_simpleconnectionselector.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_socketintercept.cpp
+++ b/libamqpprox/amqpprox_socketintercept.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_socketintercept.h
+++ b/libamqpprox/amqpprox_socketintercept.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_socketinterceptinterface.cpp
+++ b/libamqpprox/amqpprox_socketinterceptinterface.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -17,4 +17,3 @@
 #include <amqpprox_socketinterceptinterface.h>
 
 // Ensure builds independently
-

--- a/libamqpprox/amqpprox_socketinterceptinterface.h
+++ b/libamqpprox/amqpprox_socketinterceptinterface.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ class SocketInterceptInterface {
     /**
      * \brief Return if the socket is in secure mode
      */
-    virtual bool isSecure() const       = 0;
+    virtual bool isSecure() const = 0;
 
     /**
      * \brief Reset the socket's context as if it is a fresh socket
@@ -141,9 +141,9 @@ class SocketInterceptInterface {
      * \param handler The completion handler to invoke on success/error, it
      *                will also return the amount of bytes written.
      */
-    virtual void
-    async_write_some(const std::vector<std::pair<const void *, size_t>> &buffers,
-                     AsyncWriteHandler handler) = 0;
+    virtual void async_write_some(
+        const std::vector<std::pair<const void *, size_t>> &buffers,
+        AsyncWriteHandler                                   handler) = 0;
 
     /**
      * \brief Synchronously read some data onto the socket

--- a/libamqpprox/amqpprox_statcollector.cpp
+++ b/libamqpprox/amqpprox_statcollector.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statcollector.h
+++ b/libamqpprox/amqpprox_statcollector.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_statcontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statcontrolcommand.h
+++ b/libamqpprox/amqpprox_statcontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statformatter.cpp
+++ b/libamqpprox/amqpprox_statformatter.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statformatter.h
+++ b/libamqpprox/amqpprox_statformatter.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statsdpublisher.cpp
+++ b/libamqpprox/amqpprox_statsdpublisher.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statsdpublisher.h
+++ b/libamqpprox/amqpprox_statsdpublisher.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statsnapshot.cpp
+++ b/libamqpprox/amqpprox_statsnapshot.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_statsnapshot.h
+++ b/libamqpprox/amqpprox_statsnapshot.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_tlscontrolcommand.cpp
+++ b/libamqpprox/amqpprox_tlscontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -84,9 +84,9 @@ void TlsControlCommand::handleCommand(const std::string & /* command */,
         return;
     }
 
-    auto &context = (direction == "INGRESS")
-                        ? serverHandle->ingressTlsContext()
-                        : serverHandle->egressTlsContext();
+    auto &                    context = (direction == "INGRESS")
+                                            ? serverHandle->ingressTlsContext()
+                                            : serverHandle->egressTlsContext();
     boost::system::error_code ec;
 
     if ("VERIFY_MODE" == command) {

--- a/libamqpprox/amqpprox_tlscontrolcommand.h
+++ b/libamqpprox/amqpprox_tlscontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_tlsutil.cpp
+++ b/libamqpprox/amqpprox_tlsutil.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_tlsutil.h
+++ b/libamqpprox/amqpprox_tlsutil.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_types.cpp
+++ b/libamqpprox/amqpprox_types.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_types.h
+++ b/libamqpprox/amqpprox_types.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_vhostcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_vhostcontrolcommand.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_vhostcontrolcommand.h
+++ b/libamqpprox/amqpprox_vhostcontrolcommand.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_vhostestablishedpauser.h
+++ b/libamqpprox/amqpprox_vhostestablishedpauser.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/libamqpprox/amqpprox_vhoststate.cpp
+++ b/libamqpprox/amqpprox_vhoststate.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ VhostState::State::State()
 {
 }
 
-VhostState::State::State(const State& rhs)
+VhostState::State::State(const State &rhs)
 : d_paused(rhs.d_paused)
 {
 }
@@ -60,7 +60,6 @@ void VhostState::print(std::ostream &os)
                   d_vhosts.cend(),
                   std::inserter(sortedVhosts, sortedVhosts.end()));
     }
-
 
     for (const auto &vhost : sortedVhosts) {
         auto paused = (vhost.second.isPaused() ? "PAUSED" : "UNPAUSED");

--- a/libamqpprox/amqpprox_vhoststate.h
+++ b/libamqpprox/amqpprox_vhoststate.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class VhostState {
 
       public:
         State();
-        State(const State& rhs);
+        State(const State &rhs);
 
         inline bool isPaused() const { return d_paused; }
 
@@ -59,7 +59,7 @@ class VhostState {
      */
     bool isPaused(const std::string &vhost);
 
-    /** 
+    /**
      * \brief Set the specified vhost to the given paused state
      *
      * \param vhost The vhost to be manipulated
@@ -72,7 +72,7 @@ class VhostState {
      *
      * \param os The ostream to print to
      */
-    void print(std::ostream& os);
+    void print(std::ostream &os);
 };
 
 }

--- a/tests/amqpprox_affinitypartitionpolicy.t.cpp
+++ b/tests/amqpprox_affinitypartitionpolicy.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_backend.t.cpp
+++ b/tests/amqpprox_backend.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_buffer.t.cpp
+++ b/tests/amqpprox_buffer.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -60,7 +60,8 @@ TEST(Buffer, Equality)
     EXPECT_NE(b, b4);
 }
 
-TEST(Buffer, EqualContents) {
+TEST(Buffer, EqualContents)
+{
     constexpr static const char buf[]  = "HELLO";
     constexpr static const char buf2[] = "HELLO";
     Buffer                      b(buf, 6);
@@ -71,12 +72,13 @@ TEST(Buffer, EqualContents) {
     EXPECT_FALSE(b.equalContents(b3));
 }
 
-TEST(Buffer, Assign) {
-    constexpr static const char buf[]  = "HELLO";
-    std::vector<char> target(11);
-    Buffer dst(target.data(), target.size());
+TEST(Buffer, Assign)
+{
+    constexpr static const char buf[] = "HELLO";
+    std::vector<char>           target(11);
+    Buffer                      dst(target.data(), target.size());
     Buffer                      src(buf, 6);
-    
+
     bool rc = dst.assign(src);
     dst.skip(src.size());
     EXPECT_TRUE(rc);

--- a/tests/amqpprox_bufferhandle.t.cpp
+++ b/tests/amqpprox_bufferhandle.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_bufferpool.t.cpp
+++ b/tests/amqpprox_bufferpool.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_buffersource.t.cpp
+++ b/tests/amqpprox_buffersource.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_connectionstats.t.cpp
+++ b/tests/amqpprox_connectionstats.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_eventsourcesignal.t.cpp
+++ b/tests/amqpprox_eventsourcesignal.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_farmstore.t.cpp
+++ b/tests/amqpprox_farmstore.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_flowtype.t.cpp
+++ b/tests/amqpprox_flowtype.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -23,13 +23,15 @@
 using namespace Bloomberg;
 using namespace amqpprox;
 
-TEST(FlowType, StringStreamIngress) {
+TEST(FlowType, StringStreamIngress)
+{
     std::ostringstream ss;
     ss << FlowType::INGRESS;
     EXPECT_EQ(ss.str(), "INGRESS");
 }
 
-TEST(FlowType, StringStreamEgress) {
+TEST(FlowType, StringStreamEgress)
+{
     std::ostringstream ss;
     ss << FlowType::EGRESS;
     EXPECT_EQ(ss.str(), "EGRESS");

--- a/tests/amqpprox_frame.t.cpp
+++ b/tests/amqpprox_frame.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -48,13 +48,13 @@ TEST(Frame, Equality_Mismatch)
 
     EXPECT_NE(f1, f2);
 
-    f2.type = 8;
+    f2.type    = 8;
     f2.channel = 1;
 
     EXPECT_NE(f1, f2);
 
     f2.channel = 0;
-    f2.length = 1;
+    f2.length  = 1;
 
     EXPECT_NE(f1, f2);
 
@@ -194,15 +194,15 @@ TEST(Frame, BadSentinelChar)
     EXPECT_EQ(endOfFrame, nullptr);
 }
 
-TEST(Frame, Cant_Encode_Payload_Too_Large) {
+TEST(Frame, Cant_Encode_Payload_Too_Large)
+{
     Frame f1;
     f1.type    = 8;
     f1.channel = 0;
     f1.length  = Frame::getMaxFrameSize() - Frame::frameOverhead() + 1;
     f1.payload = nullptr;
 
-    void* output;
+    void *      output;
     std::size_t sz = 0;
     EXPECT_FALSE(Frame::encode(output, &sz, f1));
 }
-

--- a/tests/amqpprox_methods_start.t.cpp
+++ b/tests/amqpprox_methods_start.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ TEST(Methods_Start, Start_Decode_Fail)
     EXPECT_TRUE(encoded);
 
     Buffer encodedData = encodeBuf.currentData();
-    auto len = encodedData.size();
+    auto   len         = encodedData.size();
     for (int i = len - 1; i > 0; --i) {
         Buffer testData(encodedData.originalPtr(), i);
         Start  decodedStartMethod;

--- a/tests/amqpprox_packetprocessor.t.cpp
+++ b/tests/amqpprox_packetprocessor.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_proxyprotocolheaderv1.t.cpp
+++ b/tests/amqpprox_proxyprotocolheaderv1.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_resourcemapper.t.cpp
+++ b/tests/amqpprox_resourcemapper.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_robinbackendselector.t.cpp
+++ b/tests/amqpprox_robinbackendselector.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_sessionstate.t.cpp
+++ b/tests/amqpprox_sessionstate.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_socketintercepttestadaptor.cpp
+++ b/tests/amqpprox_socketintercepttestadaptor.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_socketintercepttestadaptor.h
+++ b/tests/amqpprox_socketintercepttestadaptor.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_statcollector.t.cpp
+++ b/tests/amqpprox_statcollector.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_statsnapshot.t.cpp
+++ b/tests/amqpprox_statsnapshot.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_testsocketstate.cpp
+++ b/tests/amqpprox_testsocketstate.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -63,8 +63,8 @@ bool TestSocketState::drive()
     bool  didWork = false;
 
     for (; step.d_produceIndex < sz; ++step.d_produceIndex) {
-        auto item           = &step.d_produce[step.d_produceIndex];
-        didWork = true;
+        auto item = &step.d_produce[step.d_produceIndex];
+        didWork   = true;
 
         if (auto state = std::get_if<State>(item)) {
             d_currentState = *state;

--- a/tests/amqpprox_testsocketstate.h
+++ b/tests/amqpprox_testsocketstate.h
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_types.t.cpp
+++ b/tests/amqpprox_types.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/tests/amqpprox_vhoststate.t.cpp
+++ b/tests/amqpprox_vhoststate.t.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Bloomberg Finance L.P.
+** Copyright 2021 Bloomberg Finance L.P.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -21,30 +21,33 @@
 
 using Bloomberg::amqpprox::VhostState;
 
-TEST(VhostState, Starts_Unpaused) {
+TEST(VhostState, Starts_Unpaused)
+{
     VhostState state;
     EXPECT_FALSE(state.isPaused("/"));
 }
 
-TEST(VhostState, Manipulate) {
+TEST(VhostState, Manipulate)
+{
     VhostState state;
 
     // Manipulate to true
     state.setPaused("/", true);
     EXPECT_TRUE(state.isPaused("/"));
-    
+
     // Check unrelated
     EXPECT_FALSE(state.isPaused("unrelated"));
 
     // Manipulate to false
     state.setPaused("/", false);
     EXPECT_FALSE(state.isPaused("/"));
-    
+
     // Check unrelated
     EXPECT_FALSE(state.isPaused("unrelated"));
 }
 
-TEST(VhostState, Print_Empty) {
+TEST(VhostState, Print_Empty)
+{
     VhostState state;
 
     std::ostringstream oss;
@@ -53,7 +56,8 @@ TEST(VhostState, Print_Empty) {
     EXPECT_EQ(oss.str(), "");
 }
 
-TEST(VhostState, Print_Two) {
+TEST(VhostState, Print_Two)
+{
     VhostState state;
     state.setPaused("foo", true);
     state.setPaused("bar", false);


### PR DESCRIPTION
We are already setting 2021 copyright year for new files. So this PR will also change year for existing files. I also noticed that  some files are changed because of clang format. I don't see any problem. I am happy to change it back, in case of any problem.