### PR TITLE
Remove unused variable length from Session:handleSessionerror function

### DIFF
--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -162,8 +162,7 @@ class Session : public std::enable_shared_from_this<Session> {
 
     void handleSessionError(const char *              action,
                             FlowType                  direction,
-                            boost::system::error_code ec,
-                            std::size_t               length);
+                            boost::system::error_code ec);
     ///< Handle errors on an established connection
 
     void handleConnectionError(


### PR DESCRIPTION
Previously, we were using the variable for logging the length. But after refactoring error handling code, that variable is not being used. So we can safely remove the parameter from Session:handleSessionerror function.

Testing performed
Build and tests passed