### PR TITLE
FieldValue: Switch to std::variant

### DIFF
--- a/libamqpprox/amqpprox_fieldvalue.cpp
+++ b/libamqpprox/amqpprox_fieldvalue.cpp
@@ -18,6 +18,7 @@
 #include <amqpprox_fieldtable.h>
 
 #include <iostream>
+#include <variant>
 
 namespace Bloomberg {
 namespace amqpprox {
@@ -68,15 +69,15 @@ std::ostream &operator<<(std::ostream &os, const FieldValue &value)
 {
     switch (value.d_type) {
     case 'F':
-        os << *boost::get<std::shared_ptr<FieldTable>>(value.d_value);
+        os << *std::get<std::shared_ptr<FieldTable>>(value.d_value);
         break;
     case 'S':
         os << "\"";
-        boost::apply_visitor(FieldValuePrinter(os), value.d_value);
+        std::visit(FieldValuePrinter(os), value.d_value);
         os << "\"";
         break;
     default:
-        boost::apply_visitor(FieldValuePrinter(os), value.d_value);
+        std::visit(FieldValuePrinter(os), value.d_value);
         break;
     }
     return os;

--- a/libamqpprox/amqpprox_fieldvalue.h
+++ b/libamqpprox/amqpprox_fieldvalue.h
@@ -16,10 +16,9 @@
 #ifndef BLOOMBERG_AMQPPROX_FIELDVALUE
 #define BLOOMBERG_AMQPPROX_FIELDVALUE
 
-#include <boost/variant.hpp>
-
 #include <iosfwd>
 #include <memory>
+#include <variant>
 #include <vector>
 
 namespace Bloomberg {
@@ -32,13 +31,13 @@ class FieldTable;
  * https://www.rabbitmq.com/amqp-0-9-1-errata.html
  */
 class FieldValue {
-    boost::variant<std::string,
-                   uint64_t,
-                   int64_t,
-                   bool,
-                   std::vector<uint8_t>,
-                   std::vector<FieldValue>,
-                   std::shared_ptr<FieldTable>>
+    std::variant<std::string,
+                 uint64_t,
+                 int64_t,
+                 bool,
+                 std::vector<uint8_t>,
+                 std::vector<FieldValue>,
+                 std::shared_ptr<FieldTable>>
          d_value;
     char d_type;
 
@@ -134,13 +133,13 @@ inline char FieldValue::type() const
 template <typename T>
 T FieldValue::value()
 {
-    return boost::get<T>(d_value);
+    return std::get<T>(d_value);
 }
 
 template <typename T>
 T FieldValue::value() const
 {
-    return boost::get<T>(d_value);
+    return std::get<T>(d_value);
 }
 
 std::ostream &operator<<(std::ostream &os, const FieldValue &value);
@@ -155,7 +154,7 @@ inline bool operator!=(const FieldValue &lhs, const FieldValue &rhs)
     return !(lhs == rhs);
 }
 
-class FieldValuePrinter : public boost::static_visitor<std::ostream &> {
+class FieldValuePrinter {
     std::ostream &d_printStream;
 
   public:


### PR DESCRIPTION
Since moving to C++17 we can replace boost::variant with std::variant.

Confirmed amqpprox runs OK and the unit tests log a method containing a FieldTable, to excercise the FieldValuePrinter.

I looked into replacing the remaining `boost::shared_ptr` usage but sadly `boost::log` won't accept a `std::shared_ptr`.
I also looked into #5 and found this will require a slightly bigger change than just switching the function names.