### PR TITLE
Set compiler c++17, if default gcc options are not available

### DIFF
--- a/buildfiles/conan/bootstrap
+++ b/buildfiles/conan/bootstrap
@@ -8,7 +8,7 @@ if [ "$(uname)" == 'Linux' ]; then
     if [[ $gcc_build_opts == *"--with-default-libstdcxx-abi=gcc4-compatible"* ]]; then
         CONANOPTS="--build missing -s compiler.libcxx=libstdc++"
     else
-        CONANOPTS="--build missing -s compiler.libcxx=libstdc++11"
+        CONANOPTS="--build missing -s compiler.libcxx=libstdc++17"
     fi
 elif [ "$(uname)" == 'Darwin' ]; then
     CONANOPTS="--build missing -s compiler.libcxx=libc++"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ amqpprox codebase.
 ## Dependencies
 
 amqpprox is designed to be lightweight in its build and runtime dependencies,
-relying only on C++11, boost and cmake. For testing, Google Test and Google Mock
+relying only on C++17, boost and cmake. For testing, Google Test and Google Mock
 are required, but are downloaded by cmake in the standalone build.
 
 Integration testing requires RabbitMQ, node and npm access, though it is most


### PR DESCRIPTION
We are already relying on C++17, so it is safe to set C++17 inside `buildfiles/conan/bootstrap`. And rectify C++ version inside `architecture.md`
