### PR TITLE
Fix copyright information

### DIFF
--- a/libamqpprox/amqpprox_vhostestablishedpauser.cpp
+++ b/libamqpprox/amqpprox_vhostestablishedpauser.cpp
@@ -1,9 +1,18 @@
 /*
- * amqpprox_vhostestablishedpauser.cpp
- * Copyright (C) 2016 alaric <alaric@nyx.local>
- *
- * Distributed under terms of the MIT license.
- */
+** Copyright 2020 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
 
 #include <amqpprox_vhostestablishedpauser.h>
 

--- a/tests/acceptance/integration/setup.sh
+++ b/tests/acceptance/integration/setup.sh
@@ -1,3 +1,18 @@
 #! /bin/sh
+
+# Copyright 2021 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 curl -s -u guest:guest -H "content-type:application/json" -XPOST http://localhost:15672/api/definitions -d @full-definitions.json
 curl -s -u guest:guest -H "content-type:application/json" -XPOST http://localhost:15675/api/definitions -d @full-definitions.json

--- a/tests/acceptance/integration/switch.sh
+++ b/tests/acceptance/integration/switch.sh
@@ -1,10 +1,18 @@
 #! /bin/bash
+
+# Copyright 2021 Bloomberg Finance L.P.
 #
-# switch.sh
-# Copyright (C) 2016 alaric <alaric@nyx.local>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Distributed under terms of the MIT license.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 DEFS_FILE=`/usr/bin/mktemp`
 QS_FILE=`/usr/bin/mktemp`

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Copyright 2021 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 export BINARY_PATH=${ROBOT_BINARY_DIR:=/usr/bin}
 export SOURCE_PATH=${SOURCE_PATH:=/source}
 export BUILD_PATH=${BUILD_PATH:=/build}


### PR DESCRIPTION
For two files, the copyright was written in old way. This PR fixes those files with standard copyright format. And also add two copyright information for other two bash files.