### PR TITLE
Link README.md as doxygen mainfile and update README.md to run doxygen command

### DIFF
--- a/Doxygen.config
+++ b/Doxygen.config
@@ -920,7 +920,8 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+INPUT += README.md
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ By default the build doesn't contain debug symbols, for Debug one can make use o
 `CMAKE_EXTRA_ARGS='-DCMAKE_BUILD_TYPE=Debug'` environment, for Release optimisations 
 one can set this to `CMAKE_EXTRA_ARGS='-DCMAKE_BUILD_TYPE=Release'` 
 
+We can also generate doxygen documentation for C++ classes.
+- `make docs`: This command will run doxygen, which is currently configured to dump generated files into `generated-docs/`.
+
 ## Installation
 
 At present we do not provide any pre-built releases and we expect users to
@@ -231,7 +234,7 @@ Before sending a [Pull Request](../../pulls), please make sure you read our
 
 ## License
 
-Please read the [LICENSE](LICENSE) file.
+Please read the [LICENSE](./LICENSE) file.
 
 ## Code of Conduct
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ amqpprox codebase.
 ## Dependencies
 
 amqpprox is designed to be lightweight in its build and runtime dependencies,
-relying only on C++11, boost and cmake. For testing, Google Test and Google Mock
+relying only on C++17, boost and cmake. For testing, Google Test and Google Mock
 are required, but are downloaded by cmake in the standalone build.
 
 Integration testing requires RabbitMQ, node and npm access, though it is most


### PR DESCRIPTION
This PR will link README.md as doxygen main landing page. Doxygen is able to render most of the .md format except ❤️  , `` backticks in header and internal links pointing to files. And also added command to run to generate doxygen doc locally. This PR also rectifies C++ version in `architecture.md` file.