### PR TITLE
Add missing copyright header on constants file.

### DIFF
--- a/libamqpprox/amqpprox_constants.h
+++ b/libamqpprox/amqpprox_constants.h
@@ -1,3 +1,18 @@
+/*
+** Copyright 2021 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
 #ifndef BLOOMBERG_AMQPPROX_CONSTANTS
 #define BLOOMBERG_AMQPPROX_CONSTANTS
 


### PR DESCRIPTION
This file must have missed the initial pass of the copyright header because it contained the term 'Copyright' already from the constant used in the protocol handshake. This adds the full header at the top of the file.