### PR TITLE
Fix multiple socket listeners

### DIFF
--- a/libamqpprox/amqpprox_server.cpp
+++ b/libamqpprox/amqpprox_server.cpp
@@ -198,14 +198,12 @@ void Server::doAccept(int port, bool secure)
 
     std::shared_ptr<MaybeSecureSocketAdaptor> incomingSocket =
         std::make_shared<MaybeSecureSocketAdaptor>(
-            d_ioService, d_ingressTlsContext, false);
+            d_ioService, d_ingressTlsContext, secure);
 
     it->second.async_accept(
         incomingSocket->socket(),
         [this, port, secure, incomingSocket](error_code ec) {
             if (!ec) {
-                incomingSocket->setSecure(secure);
-
                 MaybeSecureSocketAdaptor clientSocket(
                     d_ioService, d_egressTlsContext, false);
 

--- a/libamqpprox/amqpprox_server.h
+++ b/libamqpprox/amqpprox_server.h
@@ -19,9 +19,9 @@
 #include <amqpprox_authinterceptinterface.h>
 #include <amqpprox_connectionselector.h>
 #include <amqpprox_dnsresolver.h>
-#include <amqpprox_maybesecuresocketadaptor.h>
 
 #include <boost/asio.hpp>
+#include <boost/asio/ssl/context.hpp>
 
 #include <iosfwd>
 #include <mutex>
@@ -47,7 +47,6 @@ class Server {
     boost::asio::io_service                  d_ioService;
     boost::asio::ssl::context                d_ingressTlsContext;
     boost::asio::ssl::context                d_egressTlsContext;
-    MaybeSecureSocketAdaptor                 d_socket;
     boost::asio::deadline_timer              d_timer;
     std::unordered_map<uint64_t, SessionPtr> d_sessions;
     std::unordered_set<SessionPtr>           d_deletingSessions;


### PR DESCRIPTION
While testing we noticed that listening on multiple sockets wasn't working properly,
typically the second socket to listen was the only one to work.

It turns out this was because the ssl context held by d_socket was destructed as the
second listener's doAccept method was called. This context is passed by reference into the
asio socket, and also used by refreshSocketContext.

d_socket is only held by Server to keep it alive between doAccept() and the
async_accept callback being invoked. Changing this to a shared_ptr and passing
ownership into the callback does the same thing

The following valgrind trace was possible to produce by listening on two sockets, and connecting to the first one (with no other connections in between):

```
==7566== Memcheck, a memory error detector
==7566== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==7566== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==7566== Command: amqpprox
==7566== 
Starting amqpprox, logging to: 'logs' control using: '/tmp/amqpprox'
==7566== Invalid read of size 8
==7566==    at 0x719BAA: boost::asio::detail::io_object_impl<boost::asio::detail::reactive_socket_service<boost::asio::ip::tcp>, boost::asio::executor>::get_service() (in /opt/bb/bin/amqpprox)
==7566==    by 0x721A3C: boost::asio::basic_socket<boost::asio::ip::tcp, boost::asio::executor>::assign(boost::asio::ip::tcp const&, int const&, boost::system::error_code&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x72150B: boost::asio::detail::reactive_socket_accept_op_base<boost::asio::basic_socket<boost::asio::ip::tcp, boost::asio::executor>, boost::asio::ip::tcp>::do_assign() (in /opt/bb/bin/amqpprox)
==7566==    by 0x7157DA: boost::asio::detail::reactive_socket_accept_op<boost::asio::basic_socket<boost::asio::ip::tcp, boost::asio::executor>, boost::asio::ip::tcp, Bloomberg::amqpprox::Server::doAccept(int, bool)::{lambda(boost::system::error_code)#1}, boost::asio::detail::io_object_executor<boost::asio::executor> >::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6A9C03: boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6C01F6: boost::asio::detail::epoll_reactor::descriptor_state::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6A9C03: boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6AB7BE: boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6AB43D: boost::asio::detail::scheduler::run(boost::system::error_code&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6C04B1: boost::asio::io_context::run() (in /opt/bb/bin/amqpprox)
==7566==    by 0x712374: Bloomberg::amqpprox::Server::run() (in /opt/bb/bin/amqpprox)
==7566==    by 0x689D05: main (in /opt/bb/bin/amqpprox)
==7566==  Address 0x60e9fa0 is 0 bytes inside a block of size 320 free'd
==7566==    at 0x4C2E0A1: operator delete(void*, unsigned long) (vg_replace_malloc.c:814)
==7566==    by 0x719A1C: std::default_delete<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> > >::operator()(boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >*) const (in /opt/bb/bin/amqpprox)
==7566==    by 0x719B4A: std::unique_ptr<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >, std::default_delete<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> > > >::reset(boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >*) (in /opt/bb/bin/amqpprox)
==7566==    by 0x718607: std::unique_ptr<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >, std::default_delete<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> > > >::operator=(std::unique_ptr<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >, std::default_delete<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> > > >&&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x717CDA: Bloomberg::amqpprox::MaybeSecureSocketAdaptor::refreshSocketContext() (in /opt/bb/bin/amqpprox)
==7566==    by 0x71322E: Bloomberg::amqpprox::Server::doAccept(int, bool) (in /opt/bb/bin/amqpprox)
==7566==    by 0x712816: Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}::operator()() const (in /opt/bb/bin/amqpprox)
==7566==    by 0x7145FC: void boost::asio::asio_handler_invoke<Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}>(Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}&, ...) (in /opt/bb/bin/amqpprox)
==7566==    by 0x713F86: void boost_asio_handler_invoke_helpers::invoke<Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}, {lambda()#1}>(Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}&, {lambda()#1}&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x7151BE: void boost::asio::detail::handler_work<Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}, boost::asio::system_executor, Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}>::complete<{lambda()#1}>({lambda()#1}&, {lambda()#1}&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x714835: boost::asio::detail::completion_handler<Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6A9C03: boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) (in /opt/bb/bin/amqpprox)
==7566==  Block was alloc'd at
==7566==    at 0x4C2B753: operator new(unsigned long) (vg_replace_malloc.c:417)
==7566==    by 0x71846C: std::_MakeUniq<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> > >::__single_object std::make_unique<boost::asio::ssl::stream<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::executor> >, boost::asio::io_context&, boost::asio::ssl::context&>(boost::asio::io_context&, boost::asio::ssl::context&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x717CC3: Bloomberg::amqpprox::MaybeSecureSocketAdaptor::refreshSocketContext() (in /opt/bb/bin/amqpprox)
==7566==    by 0x71322E: Bloomberg::amqpprox::Server::doAccept(int, bool) (in /opt/bb/bin/amqpprox)
==7566==    by 0x712816: Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}::operator()() const (in /opt/bb/bin/amqpprox)
==7566==    by 0x7145FC: void boost::asio::asio_handler_invoke<Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}>(Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}&, ...) (in /opt/bb/bin/amqpprox)
==7566==    by 0x713F86: void boost_asio_handler_invoke_helpers::invoke<Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}, {lambda()#1}>(Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}&, {lambda()#1}&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x7151BE: void boost::asio::detail::handler_work<Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}, boost::asio::system_executor, Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}>::complete<{lambda()#1}>({lambda()#1}&, {lambda()#1}&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x714835: boost::asio::detail::completion_handler<Bloomberg::amqpprox::Server::startListening(int, bool)::{lambda()#1}>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6A9C03: boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6AB7BE: boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) (in /opt/bb/bin/amqpprox)
==7566==    by 0x6AB43D: boost::asio::detail::scheduler::run(boost::system::error_code&) (in /opt/bb/bin/amqpprox)

```