### PR TITLE
Start running integration tests with github action CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         uses: turtlebrowser/get-conan@v1.0
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v2
 
       # Build Steps
       - name: Setup
@@ -43,6 +43,9 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Install RabbitMQ
-        id: rabbitmq
-        uses: docker://rabbitmq:3.9.1
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Run integration tests
+      - name: Integration tests
+        run: make docker-integration-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+  # Allows to run this workflow in any kind fo release
+  release:
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -24,7 +27,7 @@ jobs:
         uses: turtlebrowser/get-conan@v1.0
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
 
       # Build Steps
       - name: Setup
@@ -33,3 +36,13 @@ jobs:
         run: make init
       - name: Build 
         run: make
+
+  integration:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Install RabbitMQ
+        id: rabbitmq
+        uses: docker://rabbitmq:3.9.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [ main ]
 
-  # Allows to run this workflow in any kind fo release
+  # Allows to run this workflow in any kind of release
   release:
 
   # Allows you to run this workflow manually from the Actions tab

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,13 @@ docker-clean:
 docker-shell:
 	docker run --privileged $(DOCKER_ARGS) bash
 
+docker-integration-tests: BUILD_FLAVOUR ?= conan
+docker-integration-tests: BUILD_DOCKERFILE ?= buildfiles/$(BUILD_FLAVOUR)/integration.Dockerfile
+docker-integration-tests:
+	docker build -t $(DOCKER_IMAGE) -f $(BUILD_DOCKERFILE) .
+	docker run $(DOCKER_IMAGE)
+
 docs:
 	doxygen Doxygen.config
 
-.PHONY: test build setup init all clean docker-setup docker-init docker-build docker-shell docs
+.PHONY: test build setup init all clean docker-setup docker-init docker-build docker-shell docker-integration-tests docs

--- a/buildfiles/conan/integration.Dockerfile
+++ b/buildfiles/conan/integration.Dockerfile
@@ -1,0 +1,26 @@
+FROM rabbitmq:3.7.9
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get dist-upgrade -y --force-yes
+RUN apt-get install -y --force-yes python3.8 python3.8-distutils \
+    curl llvm make cmake build-essential npm
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3.8 get-pip.py
+
+RUN python3.8 -m pip install setuptools conan robotframework pika amqp
+
+EXPOSE 15800
+EXPOSE 15801
+
+ENV BUILDDIR=/build
+ENV CONAN_USER_HOME=/build
+
+COPY . /source
+WORKDIR /source/tests/acceptance/integration
+RUN npm install
+WORKDIR /source
+
+RUN make setup && make init && make
+ENV ROBOT_SOURCE_DIR=/source/tests/acceptance
+ENV ROBOT_BINARY_DIR=/opt/rabbitmq/sbin
+ENTRYPOINT [ "/source/tests/acceptance/run.sh"]

--- a/tests/acceptance/libs/AMQPProx.robot
+++ b/tests/acceptance/libs/AMQPProx.robot
@@ -21,7 +21,7 @@ AMQPProx start
     Create Directory  /tmp/logs/amqpprox
     ${SOURCE_PATH}=       Get Environment Variable   SOURCE_PATH
     ${BUILD_PATH}=       Get Environment Variable   BUILD_PATH
-    ${result}=  Start Process  ${BUILD_PATH}/amqpprox/amqpprox --cleanupIntervalMs 10 --controlSocket /tmp/amqpprox --logDirectory /tmp/logs/amqpprox
+    ${result}=  Start Process  ${BUILD_PATH}/amqpprox --cleanupIntervalMs 10 --controlSocket /tmp/amqpprox --logDirectory /tmp/logs/amqpprox
     ...                      shell=yes
     [Return]    ${result}
 

--- a/tests/acceptance/libs/AMQPProxCTL.robot
+++ b/tests/acceptance/libs/AMQPProxCTL.robot
@@ -223,7 +223,7 @@ AMQPProxCTL send command
     [Arguments]   @{arguments}
     ${SOURCE_PATH}=       Get Environment Variable   SOURCE_PATH
     ${BUILD_PATH}=       Get Environment Variable   BUILD_PATH
-    ${result}=  Run Process  ${BUILD_PATH}/amqpprox_ctl/amqpprox_ctl
+    ${result}=  Run Process  ${BUILD_PATH}/amqpprox_ctl
     ...                      /tmp/amqpprox
     ...                      @{arguments}
     ...                      shell=yes

--- a/tests/acceptance/libs/RabbitMQ.robot
+++ b/tests/acceptance/libs/RabbitMQ.robot
@@ -71,6 +71,7 @@ Start rabbitmq process
     ...  console=${LOG_CONSOLE}
     Should Exist  ${configfile}.config
     ${result}=  Start Process  ${BINARY_PATH}/rabbitmq-server
+    ...            env:RABBITMQ_LOGS=/tmp/logs/${nodename}.log
     ...            env:RABBITMQ_LOG_BASE=/tmp/logs
     ...            env:RABBITMQ_PID_FILE=${pid_file}
     ...            env:RABBITMQ_NODENAME=${nodename}

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -16,7 +16,7 @@
 
 export BINARY_PATH=${ROBOT_BINARY_DIR:=/usr/bin}
 export SOURCE_PATH=${SOURCE_PATH:=/source}
-export BUILD_PATH=${BUILD_PATH:=/build}
+export BUILD_PATH=${BUILD_PATH:=/build/bin}
 export ACCEPTANCE_PATH=${ACCEPTANCE_PATH:=/source/tests/acceptance}
 export SMOKE_PATH=${SMOKE_PATH:=/source/tests/acceptance/integration}
 export WAIT_TIME=${WAIT_TIME:=30}

--- a/tests/acceptance/smoke.robot
+++ b/tests/acceptance/smoke.robot
@@ -40,7 +40,7 @@ Smoke suite setup
 
 
 *** Test Cases ***
- Smoke Test
+Smoke Test
     Log  ""  console=yes
     Make config directory
     Configure plugins

--- a/tests/acceptance/smoke.robot
+++ b/tests/acceptance/smoke.robot
@@ -40,7 +40,7 @@ Smoke suite setup
 
 
 *** Test Cases ***
-Smoke Test
+ Smoke Test
     Log  ""  console=yes
     Make config directory
     Configure plugins
@@ -69,8 +69,8 @@ Smoke Test
     ...  console=${LOG_CONSOLE}
     ${result} =  Run Process  node
     ...                       ${SMOKE_PATH}/index.js
-    ...                       ${BUILD_PATH}/amqpprox/amqpprox
-    ...                       ${BUILD_PATH}/amqpprox_ctl/amqpprox_ctl
+    ...                       ${BUILD_PATH}/amqpprox
+    ...                       ${BUILD_PATH}/amqpprox_ctl
     ...                       ${WAIT_TIME}
     ...                       stdout=STDOUT
     ...                       stderr=STDOUT


### PR DESCRIPTION
This PR adds a new make command, which will allow us to run integration tests inside docker. The PR also adds the same workflow in github actions. So now for each PR, github action will also run the integration tests against actual broker. This way we will have more confidence on our developed code.