### PR TITLE
Start static linking protobuf library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.9)
 
 project(amqpprox)
 

--- a/authproto/CMakeLists.txt
+++ b/authproto/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(Protobuf_USE_STATIC_LIBS ON)
+
 include(FindProtobuf)
 find_package(Protobuf REQUIRED)
 


### PR DESCRIPTION
Currently, used protobuf library is being linked dynamically. Protobuf library has an option to link library statically. This will increase the size of executable. But because of static linking, it will allow us to distribute executable easily on host machine without installing protobuf library explicitly.