### PR TITLE
Test docker build job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [ dockerjob ]
+    tags: [v*]
   pull_request:
     branches: [ main ]
 
@@ -49,3 +50,29 @@ jobs:
       # Run integration tests
       - name: Integration tests
         run: make docker-integration-tests
+
+  docker:
+    needs: integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: tokheim/amqpproxy
+      - name: Login to Dockerhub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          #push: ${{ github.event_name != 'pull_request' }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ dockerjob ]
+    branches: [ main ]
     tags: [v*]
   pull_request:
     branches: [ main ]
@@ -72,7 +72,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          #push: ${{ github.event_name != 'pull_request' }}
-          push: false
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM conanio/clang9 AS builder
+RUN sudo apt-get update && sudo apt-get install -y llvm
+ENV BUILDDIR=/home/conan/build
+ENV CONAN_USER_HOME=/home/conan
+COPY . ./source
+WORKDIR /home/conan/source
+RUN make setup && make init && make
+
+FROM ubuntu:focal
+WORKDIR /amqpproxy
+COPY --from=builder /home/conan/build/bin/ ./
+RUN useradd -ms /bin/bash amqpproxy && \
+    chown -R amqpproxy /amqpproxy && \
+    chmod -R 755 /amqpproxy
+USER amqpproxy
+CMD ["./amqpprox"]


### PR DESCRIPTION
Signed-off-by: Asmund Tokheim <tokheim@outlook.com>

*Issue number of the reported bug or feature request: #56 

**Describe your changes**
This introduces a root level dockerfile to build a docker image along with github actions to release the container. Just like the author of #56 I'd really need a docker image to be published in order to make use of this very promising project. The docker job is mostly based on the plain example in https://github.com/docker/metadata-action, and should push versioned images whenever you tag the repo. Still there's a lot of customization options you might want to do, so merely a suggestion from me.

**Testing performed**
I've tested the new dockerfile locally to be working. I also tested the github action on my branch, but haven't published any images, as that seemed like I was overstepping. You can see the result in https://github.com/tokheim/amqpprox/runs/4061595492

**Additional context**
Before merging you will need to change the image name, and add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets.