### PR TITLE
Client property enrichment

### DIFF
--- a/libamqpprox/amqpprox_connector.cpp
+++ b/libamqpprox/amqpprox_connector.cpp
@@ -188,7 +188,8 @@ void Connector::receive(const Method &method, FlowType direction)
             clientEndpoint.port(),
             d_localHostname,
             inboundListenPort,
-            outboundLocalPort);
+            outboundLocalPort,
+            d_sessionState_p->getIngressSecured());
 
         sendResponse(d_startOk, false);
         d_state = State::STARTOK_SENT;

--- a/libamqpprox/amqpprox_connector.cpp
+++ b/libamqpprox/amqpprox_connector.cpp
@@ -21,6 +21,7 @@
 #include <amqpprox_constants.h>
 #include <amqpprox_eventsource.h>
 #include <amqpprox_fieldtable.h>
+#include <amqpprox_fieldvalue.h>
 #include <amqpprox_flowtype.h>
 #include <amqpprox_frame.h>
 #include <amqpprox_logging.h>
@@ -445,6 +446,12 @@ void Connector::setAuthMechanismCredentials(std::string_view authMechanism,
 {
     d_startOk.setAuthMechanism(authMechanism);
     d_startOk.setCredentials(credentials);
+}
+
+void Connector::setAuthReasonAsClientProperties(std::string_view reason)
+{
+    d_startOk.properties().pushField("amqpprox_auth",
+                                     FieldValue('S', std::string(reason)));
 }
 
 }

--- a/libamqpprox/amqpprox_connector.h
+++ b/libamqpprox/amqpprox_connector.h
@@ -223,7 +223,8 @@ class Connector {
     /**
      * \brief Set the reason/detail for allowing clients to connect to amqpprox
      * proxy, if external auth service is used.
-     * \param reason reason for allowing connection
+     * \param reason for allowing connection. The reason field is returned by
+     * external configured auth service inside AuthResponse protobuf response.
      */
     void setAuthReasonAsClientProperties(std::string_view reason);
 };

--- a/libamqpprox/amqpprox_connector.h
+++ b/libamqpprox/amqpprox_connector.h
@@ -213,11 +213,19 @@ class Connector {
     /**
      * \brief Set different authentication mechanism and credentials for AMQP
      * START-OK connection method, which will be sent to server for
-     * authentication and authorization \param authMechanism of AMQP
-     * authentication mechanism \param credentials data for AMQP response field
+     * authentication and authorization
+     * \param authMechanism of AMQP authentication mechanism
+     * \param credentials data for AMQP response field
      */
     void setAuthMechanismCredentials(std::string_view authMechanism,
                                      std::string_view credentials);
+
+    /**
+     * \brief Set the reason/detail for allowing clients to connect to amqpprox
+     * proxy, if external auth service is used.
+     * \param reason reason for allowing connection
+     */
+    void setAuthReasonAsClientProperties(std::string_view reason);
 };
 
 inline Connector::State Connector::state() const

--- a/libamqpprox/amqpprox_connectorutil.cpp
+++ b/libamqpprox/amqpprox_connectorutil.cpp
@@ -82,11 +82,15 @@ void ConnectorUtil::injectProxyClientIdent(methods::StartOk * startOk,
                                            const std::string &clientHostname,
                                            int                clientRemotePort,
                                            std::string_view   localHostname,
-                                           int inboundListenPort,
-                                           int outboundLocalPort)
+                                           int  inboundListenPort,
+                                           int  outboundLocalPort,
+                                           bool isIngressSecured)
 {
     std::stringstream remoteClient;
     remoteClient << clientHostname << ":" << clientRemotePort;
+    if (isIngressSecured) {
+        remoteClient << " TLS";
+    }
     startOk->properties().pushField("amqpprox_client",
                                     FieldValue('S', remoteClient.str()));
 

--- a/libamqpprox/amqpprox_connectorutil.h
+++ b/libamqpprox/amqpprox_connectorutil.h
@@ -64,13 +64,16 @@ class ConnectorUtil {
      * \param localHostname Local hostname
      * \param inboundListenPort Inbound listen port
      * \param outboundListenPort Outbound listen port
+     * \param isIngressSecured Represents ingress connection is secured (TLS
+     * enabled)
      */
     static void injectProxyClientIdent(methods::StartOk * startOk,
                                        const std::string &clientHostname,
                                        int                clientRemotePort,
                                        std::string_view   localHostname,
                                        int                inboundListenPort,
-                                       int                outboundLocalPort);
+                                       int                outboundLocalPort,
+                                       bool               isIngressSecured);
 };
 
 }

--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -114,6 +114,8 @@ Session::Session(boost::asio::io_service &              ioservice,
         LOG_ERROR << "Setting options onto listening socket failed with: "
                   << ec;
     }
+
+    d_sessionState.setIngressSecured(this->isSecureServerSocket());
 }
 
 Session::~Session()

--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -305,6 +305,12 @@ class Session : public std::enable_shared_from_this<Session> {
      * message off the wire or not.
      */
     inline bool &currentlyReading(FlowType direction);
+
+    /**
+     * \return true if communication with server socket is secured, otherwise
+     * false. Represents whether clients communicate with proxy using TLS.
+     */
+    inline bool isSecureServerSocket();
 };
 
 inline MaybeSecureSocketAdaptor &Session::readSocket(FlowType direction)
@@ -401,6 +407,12 @@ inline bool &Session::currentlyReading(FlowType direction)
     return direction == FlowType::INGRESS ? d_ingressCurrentlyReading
                                           : d_egressCurrentlyReading;
 }
+
+inline bool Session::isSecureServerSocket()
+{
+    return d_serverSocket.isSecure();
+}
+
 }
 }
 

--- a/libamqpprox/amqpprox_sessionstate.cpp
+++ b/libamqpprox/amqpprox_sessionstate.cpp
@@ -45,6 +45,7 @@ SessionState::SessionState(
 , d_egressLatencyCount(0)
 , d_paused(false)
 , d_authDeniedConnection(false)
+, d_ingressSecured(false)
 , d_virtualHost()
 , d_disconnectedStatus(DisconnectType::NOT_DISCONNECTED)
 , d_id(s_nextId++)  // This isn't a race because this is only on one thread
@@ -109,6 +110,11 @@ void SessionState::setPaused(bool paused)
 void SessionState::setAuthDeniedConnection(bool authDenied)
 {
     d_authDeniedConnection = authDenied;
+}
+
+void SessionState::setIngressSecured(bool secured)
+{
+    d_ingressSecured = secured;
 }
 
 void SessionState::setDisconnected(SessionState::DisconnectType disconnect)

--- a/libamqpprox/amqpprox_sessionstate.h
+++ b/libamqpprox/amqpprox_sessionstate.h
@@ -60,6 +60,7 @@ class SessionState {
     std::atomic<uint64_t>           d_egressLatencyTotal;
     std::atomic<bool>               d_paused;
     std::atomic<bool>               d_authDeniedConnection;
+    std::atomic<bool>               d_ingressSecured;
     std::string                     d_virtualHost;
     DisconnectType                  d_disconnectedStatus;
     uint64_t                        d_id;
@@ -114,6 +115,13 @@ class SessionState {
      * failure
      */
     void setAuthDeniedConnection(bool authDenied);
+
+    /**
+     * \brief Set the ingress secured connection flag
+     * \param secured flag to specify the ingress connection is secured (TLS
+     * enabled)
+     */
+    void setIngressSecured(bool secured);
 
     /**
      * \brief Set session as disconnected, along with which type of disconnect
@@ -190,6 +198,12 @@ class SessionState {
     inline bool getAuthDeniedConnection() const;
 
     /**
+     * \return the state of the ingress connection, whether it is secured (TLS
+     * enabled)
+     */
+    inline bool getIngressSecured() const;
+
+    /**
      * \return session identifier
      */
     inline uint64_t id() const;
@@ -240,6 +254,11 @@ inline bool SessionState::getPaused() const
 inline bool SessionState::getAuthDeniedConnection() const
 {
     return d_authDeniedConnection;
+}
+
+inline bool SessionState::getIngressSecured() const
+{
+    return d_ingressSecured;
 }
 
 inline uint64_t SessionState::id() const

--- a/libamqpprox/amqpprox_vhostcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_vhostcontrolcommand.cpp
@@ -17,7 +17,6 @@
 
 #include <amqpprox_server.h>
 #include <amqpprox_session.h>
-#include <amqpprox_sessionstate.h>
 #include <amqpprox_vhoststate.h>
 
 #include <sstream>

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -346,7 +346,8 @@ void SessionTest::testSetupProxySendsStartOk(
                                  injectedClientPort,
                                  injectedProxyHost,
                                  injectedProxyInboundPort,
-                                 injectedProxyOutboundPort);
+                                 injectedProxyOutboundPort,
+                                 false);
 
                              EXPECT_EQ(data[0], Data(encode(startOk)));
                          });

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -1300,9 +1300,10 @@ TEST_F(SessionTest, Authorized_Client_Test)
 
     std::string             modifiedMechanism   = "TEST_MECHANISM";
     std::string             modifiedCredentials = "credentials";
+    std::string             reason              = "Authorized test client";
     authproto::AuthResponse authResponseData;
     authResponseData.set_result(authproto::AuthResponse::ALLOW);
-    authResponseData.set_reason("Authorized test client");
+    authResponseData.set_reason(reason);
     authproto::SASL *saslPtr = authResponseData.mutable_authdata();
     saslPtr->set_authmechanism(modifiedMechanism);
     saslPtr->set_credentials(modifiedCredentials);
@@ -1342,6 +1343,8 @@ TEST_F(SessionTest, Authorized_Client_Test)
     methods::StartOk overriddenStartOk = clientStartOk();
     overriddenStartOk.setAuthMechanism(modifiedMechanism);
     overriddenStartOk.setCredentials(modifiedCredentials);
+    overriddenStartOk.properties().pushField("amqpprox_auth",
+                                             FieldValue('S', reason));
     testSetupProxySendsStartOk(
         7, "host1", 2345, LOCAL_HOSTNAME, 1234, 32000, overriddenStartOk);
     testSetupProxyOpen(8);


### PR DESCRIPTION
Currently, if user connects to amqpprox proxy on secure port using TLS, there is now way we can differentiate the normal connection against TLS connection using RabbitMQ management UI. This PR appends TLS keyword with `amqpprox_client` field value inside client properties to denote the TLS enabled connection. This way operator will be able differentiate the two different type of connections using RabbitMQ management UI.

Secondly, if we use external authentication service using configured `AUTH` command, then also we cannot differentiate the normal connection and connection authorised by external service. So this PR adds an extra field `amqpprox_auth` inside client properties, which will tell the reason behind auth using RabbitMQ management UI.