### PR TITLE
Set custom error message inside connection close method for unauthorised client

### DIFF
--- a/libamqpprox/amqpprox_connector.h
+++ b/libamqpprox/amqpprox_connector.h
@@ -29,6 +29,7 @@
 #include <amqpprox_methods_startok.h>
 #include <amqpprox_methods_tune.h>
 #include <amqpprox_methods_tuneok.h>
+#include <amqpprox_reply.h>
 
 #include <functional>
 #include <string_view>
@@ -101,9 +102,10 @@ class Connector {
     template <typename T>
     void sendResponse(const T &response, bool sendToIngressSide);
 
-    template <typename TReply, typename TMethod>
-    inline void synthesizeMessage(TMethod &replyMethod,
-                                  bool     sendToIngressSide);
+    inline void synthesizeMessage(methods::Close & replyMethod,
+                                  bool             sendToIngressSide,
+                                  uint64_t         code,
+                                  std::string_view text);
 
   public:
     Connector(SessionState *   sessionState,
@@ -159,12 +161,16 @@ class Connector {
     void synthesizeCloseError(bool sendToIngressSide);
 
     /**
-     * \brief Send AMQP connection Close method with ERROR status to
-     * client/server based on specified direction
+     * \brief Send AMQP connection Close method with custom ERROR code and text
+     * to client/server based on specified direction
      * \param sendToIngressSide true for communicating with client and false
      * for communicating with server
+     * \param code custom error code
+     * \param text custom error text
      */
-    void synthesizeCloseAuthError(bool sendToIngressSide);
+    void synthesizeCustomCloseError(bool             sendToIngressSide,
+                                    uint16_t         code,
+                                    std::string_view text);
 
     /**
      * \brief Synthesize AMQP protocol header buffer, which will eventually be

--- a/libamqpprox/amqpprox_reply.h
+++ b/libamqpprox/amqpprox_reply.h
@@ -50,22 +50,6 @@ struct Codes {
     };
 };
 
-struct OK {
-    constexpr static const uint16_t    CODE = Codes::reply_success;
-    constexpr static const char *const TEXT = "OK";
-};
-
-struct CloseAuthDeny {
-    constexpr static const uint16_t    CODE = Codes::access_refused;
-    constexpr static const char *const TEXT =
-        "ERROR: Not authorized by amqpprox proxy";
-};
-
-struct CloseOkExpected {
-    constexpr static const uint16_t    CODE = Codes::channel_error;
-    constexpr static const char *const TEXT = "ERROR: Expected CloseOk reply";
-};
-
 }
 }
 }

--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -128,8 +128,10 @@ class Session : public std::enable_shared_from_this<Session> {
      * https://www.rabbitmq.com/auth-notification.html
      * \param clientProperties will be used to find the client
      * 'authentication_failure_close' capability value
+     * \param reason custom reason/message for unauthorized client
      */
-    void disconnectUnauthClient(const FieldTable &clientProperties);
+    void disconnectUnauthClient(const FieldTable &clientProperties,
+                                std::string_view  reason);
 
     /**
      * \brief Disconnect the session from the backend, but leave the client

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -264,8 +264,8 @@ void SessionTest::testSetupUnauthClientOpenWithShutdown(
     d_serverState.pushItem(idx, Data(encode(clientTuneOk())));
     d_serverState.pushItem(idx, Data(encode(clientOpen())));
     methods::Close closeMethod = methods::Close();
-    closeMethod.setReply(Reply::CloseAuthDeny::CODE,
-                         Reply::CloseAuthDeny::TEXT);
+    closeMethod.setReply(Reply::Codes::access_refused,
+                         "Unauthorized test client");
     d_serverState.expect(
         idx,
         [this, closeMethod, authenticationFailureClose](const auto &items) {
@@ -1788,6 +1788,6 @@ methods::CloseOk SessionTest::closeOk()
 methods::Close SessionTest::close()
 {
     auto result = methods::Close();
-    result.setReply(Reply::OK::CODE, Reply::OK::TEXT);
+    result.setReply(Reply::Codes::reply_success, "OK");
     return result;
 }


### PR DESCRIPTION
Proxy can also be configured to use external http service to authenticate clients. But currently, if the external auth service fail to authenticate client, proxy will close the client connection with default message "ERROR: Not authorized by amqpprox proxy". It will be difficult for that client to debug the actual problem in that case. So this PR will propagate the reason, which proxy got from the external http service to the client. And client will immediately be able to know the actual reason in such cases.