### PR TITLE
BackendStore: Remove (ip,port) -> Backend mapping

### DIFF
--- a/libamqpprox/amqpprox_backendstore.h
+++ b/libamqpprox/amqpprox_backendstore.h
@@ -30,16 +30,14 @@ namespace amqpprox {
  * \brief Represents Backend store
  */
 class BackendStore {
-    std::unordered_map<std::string, Backend>               d_backends;
-    std::map<std::pair<std::string, int>, const Backend *> d_backendAddresses;
-    mutable std::mutex                                     d_mutex;
+    std::unordered_map<std::string, Backend> d_backends;
+    mutable std::mutex                       d_mutex;
 
   public:
     BackendStore();
     int insert(const Backend &backend);
     int remove(const std::string &name);
 
-    const Backend *lookup(const std::string &ip, int port) const;
     const Backend *lookup(const std::string &name) const;
     void           print(std::ostream &os) const;
 };

--- a/tests/amqpprox_backendstore.t.cpp
+++ b/tests/amqpprox_backendstore.t.cpp
@@ -69,29 +69,6 @@ TEST(BackendStore, Lookup_Items_By_Name)
     EXPECT_EQ(*b2, backend2);
 }
 
-TEST(BackendStore, Lookup_Items_By_Address)
-{
-    BackendStore store;
-    Backend backend1(
-        "backend1", "dc1", "backend1.bloomberg.com", "127.0.0.1", 5672, true);
-    Backend backend2(
-        "backend2", "dc2", "backend2.bloomberg.com", "127.0.0.2", 5672, true);
-
-    EXPECT_EQ(store.insert(backend1), 0);
-    EXPECT_EQ(store.insert(backend2), 0);
-
-    // Non existing still fails
-    EXPECT_EQ(store.lookup("backend3"), nullptr);
-
-    auto b1 = store.lookup("127.0.0.1", 5672);
-    auto b2 = store.lookup("127.0.0.2", 5672);
-
-    ASSERT_NE(b1, nullptr);
-    ASSERT_NE(b2, nullptr);
-    EXPECT_EQ(*b1, backend1);
-    EXPECT_EQ(*b2, backend2);
-}
-
 TEST(BackendStore, CollidingItems) {
     BackendStore store;
     Backend backend1(


### PR DESCRIPTION
Reported in #63, the extra mapping of (ip, port) -> Backend prevents
inserting two backends with different names but the same port, which
will break a very common configuration.

There is no usage of this extra BackendStore mapping, outside of unit
tests.

An (internal) git history search for `git log -S lookup -p` also suggests
there has never been any usage of this method.

Let's remove it & fix this behaviour - thanks for the report @kriptor

Closes #63 