### PR TITLE
Workaround asio::ssl async_read_some busy-loop

### DIFF
--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -70,13 +70,13 @@ namespace amqpprox {
 using namespace boost::asio::ip;
 using namespace boost::system;
 
-Session::Session(boost::asio::io_service &              ioservice,
-                 MaybeSecureSocketAdaptor &&            serverSocket,
-                 MaybeSecureSocketAdaptor &&            clientSocket,
-                 ConnectionSelector *                   connectionSelector,
-                 EventSource *                          eventSource,
-                 BufferPool *                           bufferPool,
-                 DNSResolver *                          dnsResolver,
+Session::Session(boost::asio::io_service               &ioservice,
+                 MaybeSecureSocketAdaptor             &&serverSocket,
+                 MaybeSecureSocketAdaptor             &&clientSocket,
+                 ConnectionSelector                    *connectionSelector,
+                 EventSource                           *eventSource,
+                 BufferPool                            *bufferPool,
+                 DNSResolver                           *dnsResolver,
                  const std::shared_ptr<HostnameMapper> &hostnameMapper,
                  std::string_view                       localHostname,
                  const std::shared_ptr<AuthInterceptInterface> &authIntercept)
@@ -184,7 +184,7 @@ void Session::attemptConnection(
     using endpointType = boost::asio::ip::tcp::endpoint;
     auto self(shared_from_this());
     auto callback = [this, self, connectionManager](
-                        const error_code &        ec,
+                        const error_code         &ec,
                         std::vector<endpointType> endpoints) {
         BOOST_LOG_SCOPED_THREAD_ATTR(
             "Vhost",
@@ -682,6 +682,11 @@ void Session::readData(FlowType direction)
                 readData(direction);
             }
             else {
+                if (readAmount > 0) {
+                    LOG_TRACE << "read_some returned data and error. Data "
+                                 "discarded from "
+                              << direction << " to close sockets";
+                }
                 handleSessionError("read_some", direction, ec);
                 return;
             }
@@ -754,7 +759,7 @@ void Session::handleData(FlowType direction)
     }
 }
 
-void Session::handleSessionError(const char *              action,
+void Session::handleSessionError(const char               *action,
                                  FlowType                  direction,
                                  boost::system::error_code ec)
 {
@@ -818,7 +823,7 @@ void Session::handleSessionError(const char *              action,
 }
 
 void Session::handleConnectionError(
-    const char *                              action,
+    const char                               *action,
     boost::system::error_code                 ec,
     const std::shared_ptr<ConnectionManager> &connectionManager)
 {


### PR DESCRIPTION
`asio::ssl` has a bug where calling async_read_some with `null_buffers`
isn't correctly handled, and more or less immediately invokes the
provided handler with no data. This causes `amqpprox` to busy-loop
whenever a TLS socket has been accepted or opened.

There were two options for how to address this in our code:

1) Always read with a fixed size buffer, such as 32kb. This would
   simplify the code slightly, at the expense of needing multiple reads
   to handle larger than 32kb frames in non-TLS mode, even when the full
   frame is available to `amqpprox` in one go.
2) Ask asio::ssl to read with a very small buffer, then ask the openssl
   library how many bytes are available. This technique aligns with how
   `amqpprox`'s read loop works today. That is what is implemented here.

In theory something similar could be upstreamed into `asio::ssl`. It's a
little tricky though and this exact code couldn't handle the generic
`MutableBufferSequence` interface - we can take some shortcuts in our
code.

I've done some benchmarking to check this change isn't going to regress
performance noticeably. Data throughput tests indicate that this fix improves
performance for TLS connections over the existing code.

## Performance Tests

Testing by setting up amqpprox as per the performance tests README.md, and running the perf tester like:
```
$ ./amqpprox_perf_tester --address amqp://localhost:30671 --listen-address 0.0.0.0:5671 --clients 10 --max-threads 10 --message-size 10000000 --num-messages 100 --listen-cert amqpprox/cert.pem --listen-key amqpprox/key.pem
```
Results in MiB/s over a ~20second run

Test # | no TLS | no TLS | no TLS | TLS | TLS | TLS
-- | -- | -- | -- | -- | -- | --
Code | Current | Fixed Buffer 32K | This PR | Current | Fixed Buffer 32K | This PR
1 | 898 | 1038 | 824 | 426 | 515 | 505
2 | 965 | 902 | 1007 | 470 | 535 | 514
3 | 1050 | 888 | 918 | 475 | 553 | 555

This shows there isn't really any chance to non-TLS performance, and there is a slight increase in throughput with this code change (or the fixed-buffer size change).

## ~~Still TODO~~

 - [x] Check against a few rabbitmq client libraries. Ensure I'm not missing something obvious
 - [x] Consider deleting the other `async_read_some` definition since it should be unused
 - [x] Run connection throughput tests. Measure memory usage for thousands of outstanding connections.
 
 Ref: https://github.com/chriskohlhoff/asio/issues/1015