### PR TITLE
perf tester: Count messages/handle channel close/listen backlog

### DIFF
--- a/tests/performance_tester/src/client.rs
+++ b/tests/performance_tester/src/client.rs
@@ -33,7 +33,7 @@ pub(crate) fn run_sync_client(
 
     let mut count = 0;
     loop {
-        if count > num_messages {
+        if count >= num_messages {
             break;
         }
         exchange.publish(Publish::new(&arr, routing_key))?;

--- a/tests/performance_tester/src/client.rs
+++ b/tests/performance_tester/src/client.rs
@@ -41,7 +41,7 @@ pub(crate) fn run_sync_client(
         count += 1;
     }
 
-    connection.close()?;
+    let _ = connection.close();
 
     Ok(())
 }

--- a/tests/performance_tester/src/client.rs
+++ b/tests/performance_tester/src/client.rs
@@ -41,5 +41,7 @@ pub(crate) fn run_sync_client(
         count += 1;
     }
 
+    connection.close()?;
+
     Ok(())
 }

--- a/tests/performance_tester/src/main.rs
+++ b/tests/performance_tester/src/main.rs
@@ -95,9 +95,7 @@ fn main() -> Result<()> {
             {
                 println!("Starting TLS dummy amqp server");
                 let acceptor = server::create_tls_acceptor(&listen_cert, &listen_key).unwrap();
-                tokio::spawn(async move {
-                    server::run_tls_server(address, acceptor).await
-                })
+                tokio::spawn(async move { server::run_tls_server(address, acceptor).await })
             } else {
                 println!("Starting non-TLS dummy amqp server");
                 tokio::spawn(async move { server::run_server(address).await })
@@ -115,7 +113,12 @@ fn main() -> Result<()> {
                 let routing_key = opts.routing_key.clone();
 
                 let handle = tokio::task::spawn_blocking(move || {
-                    crate::client::run_sync_client(address, message_size, num_messages, &routing_key)
+                    crate::client::run_sync_client(
+                        address,
+                        message_size,
+                        num_messages,
+                        &routing_key,
+                    )
                 });
                 handles.push(handle);
             }
@@ -173,7 +176,9 @@ async fn wait_for_addr(addr: SocketAddr, timeout_total: Duration) -> Result<()> 
             }
         }
 
-        let target = start.checked_add(timeout_step).ok_or(anyhow::anyhow!("Timeout add overflowed"))?;
+        let target = start
+            .checked_add(timeout_step)
+            .ok_or(anyhow::anyhow!("Timeout add overflowed"))?;
         if let Some(sleep_time) = target.checked_duration_since(Instant::now()) {
             tokio::time::sleep(sleep_time).await;
         }


### PR DESCRIPTION
While testing #69 I found a few issues with the perf tester:

1. A packet capture showed that we were sending two messages when it should only send one.
2. Same capture showed that there was a shutdown issue due to amiquip sending channel close and us replying with channel openok - oops. The channel close doesn't seem to be sent since making the connection close explicit, but I left this fix in for future use.
3. Changed the connection close to be explicit. But I am purposefully ignoring the result since sometimes this fails - which just seems to be when the server shuts the socket down before the client - when testing locally it seems like the client sends `FIN` first most of the time. I feel like the amqp library should probably ignore this case, but I'm also not sure how amqpprox handles this either so I probably can't be too upset - we do log a lot when connection are closing.