### PR TITLE
Start logging correct tune method received from server

### DIFF
--- a/libamqpprox/amqpprox_connector.cpp
+++ b/libamqpprox/amqpprox_connector.cpp
@@ -195,9 +195,10 @@ void Connector::receive(const Method &method, FlowType direction)
         sendResponse(d_startOk, false);
         d_state = State::STARTOK_SENT;
     } break;
+    // Acting as a client
     case State::STARTOK_SENT: {
         decodeMethod(&d_receivedTune, method, methodPayload);
-        LOG_TRACE << "Tune: " << d_receivedStart;
+        LOG_TRACE << "Server Tune: " << d_receivedTune;
 
         sendResponse(d_tuneOk, false);
         sendResponse(d_open, false);


### PR DESCRIPTION
When amqpprox sends the start-ok method, server returns the tune method. But at that point, we are logging start-ok method, instead of logging correct received tune method. This PR fixes that issue. And also explicitly adds the Server string to represent method received from server, as we are doing for other methods. This log trace is useful, while analysing amqpprox logs.