### PR TITLE
Expose received broker connection close method, in case of any error, to client during handshake

### DIFF
--- a/libamqpprox/CMakeLists.txt
+++ b/libamqpprox/CMakeLists.txt
@@ -84,7 +84,8 @@ add_library(libamqpprox STATIC
     amqpprox_authinterceptinterface.cpp
     amqpprox_defaultauthintercept.cpp
     amqpprox_httpauthintercept.cpp
-    amqpprox_authcontrolcommand.cpp)
+    amqpprox_authcontrolcommand.cpp
+    amqpprox_closeerror.cpp)
 
 target_include_directories(libamqpprox PRIVATE ${PROTO_HDR_PATH})
 target_link_libraries(libamqpprox LINK_PUBLIC authproto ${LIBAMQPPROX_LIBS})

--- a/libamqpprox/amqpprox_closeerror.cpp
+++ b/libamqpprox/amqpprox_closeerror.cpp
@@ -1,0 +1,36 @@
+/*
+** Copyright 2022 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_closeerror.h>
+#include <amqpprox_methods_close.h>
+#include <stdexcept>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+CloseError::CloseError(const std::string &msg, methods::Close &closeMethod)
+: std::runtime_error(msg)
+, d_closeMethod(closeMethod)
+{
+}
+
+methods::Close CloseError::closeMethod() const
+{
+    return d_closeMethod;
+}
+
+}
+}

--- a/libamqpprox/amqpprox_closeerror.h
+++ b/libamqpprox/amqpprox_closeerror.h
@@ -1,0 +1,52 @@
+/*
+** Copyright 2022 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef BLOOMBERG_AMQPPROX_CLOSEERROR
+#define BLOOMBERG_AMQPPROX_CLOSEERROR
+
+#include <amqpprox_methods_close.h>
+#include <stdexcept>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+/**
+ * \brief Custom exception class
+ *
+ * This class will be used to throw custom exception, whenever we get the
+ * unexpected connection Close method from server during handshake. Using this
+ * exception, we are going to pass connection Close method to the exception
+ * handler. The exception handler eventually can send the Close method to
+ * clients for better error handling.
+ */
+class CloseError : public std::runtime_error {
+    methods::Close d_closeMethod;
+
+  public:
+    // CREATORS
+    CloseError(const std::string &msg, methods::Close &closeMethod);
+
+    // ACCESSORS
+    /**
+     * \return connection Close method
+     */
+    methods::Close closeMethod() const;
+};
+
+}
+}
+
+#endif


### PR DESCRIPTION
At the moment, if client is not able to connect to broker because of reasons like invalid credentials, port, user or anything else, broker sends the connection Close method to the amqpprox server. And amqpprox immediately shutdowns and closes the sockets for clients. Because of that, client never receives the connection Close method, which is not good for the client. Because the Close method specifies the reason behind the closing the connection abruptly and it would be hard for client to debug any existing problem. So this PR fixes that issue. And it forwards the received connection close method to client. This way client will be able to know the reason of closure during handshake. And then it continues to shutdown and close sockets. Once we have the successful connection, amqpprox will forwards complete traffic to client as usual.

For example, if any client tries to connect to any vhost using wrong credentials, amqpprox will get the connection Close method from the server. And amqpprox will forward this method to client, before shutting down the socket.

Sample received Close method on client side, which describes the correct reason of the disconnection:
```
Received message: MESSAGE=Connection Close = [replyCode: 403, replyText: "ACCESS_REFUSED - Login was refused using authentication mechanism PLAIN. For details see the broker logfile.", classId: 0, methodId: 0] CHANNEL=0 LEN=119
```

