### PR TITLE
Change from shutdown to async_shutdown and don't wait for remote

### DIFF
--- a/libamqpprox/amqpprox_httpauthintercept.cpp
+++ b/libamqpprox/amqpprox_httpauthintercept.cpp
@@ -262,6 +262,7 @@ void HttpAuthIntercept::onRead(
     // Gracefully close the socket
     stream->socket().shutdown(tcp::socket::shutdown_both, ec);
 
+    // TODO shouldn't we also call stream->socket().close()?
     // not_connected happens sometimes so don't bother reporting it.
     if (ec && ec != beast::errc::not_connected) {
         const std::string errorMsg =

--- a/libamqpprox/amqpprox_logging.h
+++ b/libamqpprox/amqpprox_logging.h
@@ -37,6 +37,7 @@
 #define LOG_WARN BOOST_LOG_SEV(Logging::get(), Logging::AMQPPROX_LOG_WARN)
 #define LOG_ERROR BOOST_LOG_SEV(Logging::get(), Logging::AMQPPROX_LOG_ERROR)
 #define LOG_FATAL BOOST_LOG_SEV(Logging::get(), Logging::AMQPPROX_LOG_FATAL)
+#define LOG_SEV(sev) BOOST_LOG_SEV(Logging::get(), sev)
 
 namespace Bloomberg {
 namespace amqpprox {

--- a/libamqpprox/amqpprox_socketintercept.cpp
+++ b/libamqpprox/amqpprox_socketintercept.cpp
@@ -47,11 +47,6 @@ SocketIntercept::local_endpoint(boost::system::error_code &ec)
     return d_impl.local_endpoint(ec);
 }
 
-void SocketIntercept::shutdown(boost::system::error_code &ec)
-{
-    d_impl.shutdown(ec);
-}
-
 void SocketIntercept::close(boost::system::error_code &ec)
 {
     d_impl.close(ec);

--- a/libamqpprox/amqpprox_socketintercept.h
+++ b/libamqpprox/amqpprox_socketintercept.h
@@ -43,6 +43,8 @@ class SocketIntercept {
         std::function<void(boost::system::error_code, std::size_t)>;
     using AsyncHandshakeHandler =
         std::function<void(boost::system::error_code)>;
+    using AsyncShutdownHandler =
+        std::function<void(boost::system::error_code)>;
     using AsyncConnectHandler = std::function<void(boost::system::error_code)>;
 
     SocketInterceptInterface &d_impl;
@@ -101,12 +103,6 @@ class SocketIntercept {
     endpoint local_endpoint(boost::system::error_code &ec);
 
     /**
-     * \brief Shutdown the socket for read and write.
-     * \param ec The error code set by the operation, only changed on error.
-     */
-    void shutdown(boost::system::error_code &ec);
-
-    /**
      * \brief Close the socket
      * \param ec The error code set by the operation, only changed on error.
      */
@@ -156,6 +152,19 @@ class SocketIntercept {
                     BOOST_ASIO_MOVE_ARG(HandshakeHandler) handler)
     {
         d_impl.async_handshake(type, handler);
+    }
+
+    /**
+     * \brief Initiate shutdown for it will only be truly asynchronous for TLS
+     * as TLS needs to write close_notify as part of shutdown
+     * \param handler The completion handler to invoke on success/error
+     */
+    template <typename ShutdownHandler>
+    BOOST_ASIO_INITFN_RESULT_TYPE(ShutdownHandler,
+                                  void(boost::system::error_code))
+    async_shutdown(BOOST_ASIO_MOVE_ARG(ShutdownHandler) handler)
+    {
+        d_impl.async_shutdown(handler);
     }
 
     /**

--- a/libamqpprox/amqpprox_socketinterceptinterface.h
+++ b/libamqpprox/amqpprox_socketinterceptinterface.h
@@ -40,6 +40,8 @@ class SocketInterceptInterface {
         std::function<void(boost::system::error_code, std::size_t)>;
     using AsyncHandshakeHandler =
         std::function<void(boost::system::error_code)>;
+    using AsyncShutdownHandler =
+        std::function<void(boost::system::error_code)>;
     using AsyncConnectHandler = std::function<void(boost::system::error_code)>;
 
     /**
@@ -83,12 +85,6 @@ class SocketInterceptInterface {
     virtual endpoint local_endpoint(boost::system::error_code &ec) = 0;
 
     /**
-     * \brief Shutdown the socket for read and write.
-     * \param ec The error code set by the operation, only changed on error.
-     */
-    virtual void shutdown(boost::system::error_code &ec) = 0;
-
-    /**
      * \brief Close the socket
      * \param ec The error code set by the operation, only changed on error.
      */
@@ -130,6 +126,14 @@ class SocketInterceptInterface {
      */
     virtual void async_handshake(handshake_type        type,
                                  AsyncHandshakeHandler handler) = 0;
+
+    /**
+     * \brief Initiate shutdown
+     *
+     *
+     * \param handler The completion handler to invoke on success/error
+     */
+    virtual void async_shutdown(AsyncShutdownHandler handler) = 0;
 
     /**
      * \brief Write some data onto the socket

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -302,11 +302,13 @@ void SessionTest::testSetupUnauthClientOpenWithShutdown(
                 ASSERT_EQ(data.size(), 1);
                 EXPECT_EQ(data[0], Data(encode(closeMethod)));
             }
-            EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+            EXPECT_THAT(items,
+                        Contains(VariantWith<Call>(Call("async_shutdown"))));
             EXPECT_THAT(items, Contains(VariantWith<Call>(Call("close"))));
         });
     d_clientState.expect(idx, [this](const auto &items) {
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
         EXPECT_THAT(items, Contains(VariantWith<Call>(Call("close"))));
     });
 }
@@ -316,7 +318,8 @@ void SessionTest::testSetupClientOpenWithoutTune(int idx)
     // Client  ------Open-------->  Proxy                         Broker
     d_serverState.pushItem(idx, Data(encode(clientOpen())));
     d_clientState.expect(idx, [this](const auto &items) {
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
     });
 }
 
@@ -386,10 +389,12 @@ void SessionTest::testSetupProxyOutOfOrderOpen(int idx)
     // Client                       Proxy  <--------OpenOk------ Broker
     d_clientState.pushItem(idx, Data(encode(serverOpenOk())));
     d_clientState.expect(idx, [this](const auto &items) {
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
     });
     d_serverState.expect(idx, [this](const auto &items) {
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
     });
 }
 
@@ -404,11 +409,13 @@ void SessionTest::testSetupProxyForwardsBrokerClose(int idx)
         auto data = filterVariant<Data>(items);
         ASSERT_EQ(data.size(), 1);
         EXPECT_EQ(data[0], Data(encode(receivedClose)));
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
         EXPECT_THAT(items, Contains(VariantWith<Call>(Call("close"))));
     });
     d_clientState.expect(idx, [this](const auto &items) {
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
         EXPECT_THAT(items, Contains(VariantWith<Call>(Call("close"))));
     });
 }
@@ -501,11 +508,13 @@ void SessionTest::testSetupBrokerRespondsCloseOk(int idx)
     // before we get to close ourselves.
     d_clientState.pushItem(idx, Data(encode(closeOk())));
     d_clientState.expect(idx, [this](const auto &items) {
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
         EXPECT_THAT(items, Contains(VariantWith<Call>(Call("close"))));
     });
     d_serverState.expect(idx, [this](const auto &items) {
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
         EXPECT_THAT(items, Contains(VariantWith<Call>(Call("close"))));
     });
 }
@@ -1240,11 +1249,13 @@ TEST_F(SessionTest, Connection_Then_Ping_Then_Backend_Disconnect)
                            Func([&session] { session->backendDisconnect(); }));
 
     d_clientState.expect(12, [this](const auto &items) {
-        EXPECT_THAT(items, Contains(VariantWith<Call>(Call("shutdown"))));
+        EXPECT_THAT(items,
+                    Contains(VariantWith<Call>(Call("async_shutdown"))));
         EXPECT_THAT(items, Contains(VariantWith<Call>(Call("close"))));
     });
     d_serverState.expect(12, [this](const auto &items) {
-        EXPECT_THAT(items, Not(Contains(VariantWith<Call>(Call("shutdown")))));
+        EXPECT_THAT(items,
+                    Not(Contains(VariantWith<Call>(Call("async_shutdown")))));
         EXPECT_THAT(items, Not(Contains(VariantWith<Call>(Call("close")))));
     });
 

--- a/tests/amqpprox_socketintercepttestadaptor.cpp
+++ b/tests/amqpprox_socketintercepttestadaptor.cpp
@@ -61,11 +61,6 @@ SocketInterceptTestAdaptor::local_endpoint(boost::system::error_code &ec)
     return d_state.currentState().d_local;
 }
 
-void SocketInterceptTestAdaptor::shutdown(boost::system::error_code &ec)
-{
-    d_state.recordCallCheck("shutdown", ec);
-}
-
 void SocketInterceptTestAdaptor::close(boost::system::error_code &ec)
 {
     d_state.recordCallCheck("close", ec);
@@ -87,6 +82,16 @@ SocketInterceptTestAdaptor::available(boost::system::error_code &ec)
     }
 
     throw std::runtime_error("No item available");
+}
+
+void SocketInterceptTestAdaptor::async_shutdown(AsyncShutdownHandler handler)
+{
+    d_state.recordCall("async_shutdown");
+    boost::system::error_code ec;
+    if (d_state.currentState().d_secure) {
+        ec = boost::asio::ssl::error::stream_truncated;
+    }
+    handler(ec);
 }
 
 void SocketInterceptTestAdaptor::async_connect(const endpoint &peer_endpoint,

--- a/tests/amqpprox_socketintercepttestadaptor.h
+++ b/tests/amqpprox_socketintercepttestadaptor.h
@@ -67,6 +67,8 @@ class SocketInterceptTestAdaptor : public SocketInterceptInterface {
     using AsyncHandshakeHandler =
         std::function<void(boost::system::error_code)>;
     using AsyncConnectHandler = std::function<void(boost::system::error_code)>;
+    using AsyncShutdownHandler =
+        std::function<void(boost::system::error_code)>;
 
     // CREATORS
     /**
@@ -84,13 +86,13 @@ class SocketInterceptTestAdaptor : public SocketInterceptInterface {
 
     virtual endpoint local_endpoint(boost::system::error_code &ec) override;
 
-    virtual void shutdown(boost::system::error_code &ec) override;
-
     virtual void close(boost::system::error_code &ec) override;
 
     virtual void setDefaultOptions(boost::system::error_code &ec) override;
 
     virtual std::size_t available(boost::system::error_code &ec) override;
+
+    virtual void async_shutdown(AsyncShutdownHandler handler) override;
 
     virtual void async_connect(const endpoint &    peer_endpoint,
                                AsyncConnectHandler handler) override;


### PR DESCRIPTION
close_notify

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
This change, shifts calls to shutdown to async_shutdown for TLS connections, there are name only changes for regular (non tls connections) 

**Testing performed**
Unit tests updated

**Additional context**
Closing receive channel of the socket is intentional when the close is initiated from amqpprox as the protocol doesn't mandate you wait for the remote close_notify to be received (only that you send a close_notify) see https://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error for more info.

Suppressed some of the logging as it's normal to observe a close_notify and previously this was logged at error severity (its not an error)

