### PR TITLE
Add missing  VHOST config command for amqpprox_ctl

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -28,6 +28,7 @@ MAPHOSTNAME DNS - Set up mapping of IPs to hostnames
 SESSION  id# (PAUSE|DISCONNECT_GRACEFUL|FORCE_DISCONNECT) - Control a particular session
 STAT (STOP SEND | SEND <host> <port> | (LISTEN (json|human) (overall|vhost=foo|backend=bar|source=baz|all|process|bufferpool)) - Output statistics
 TLS (INGRESS | EGRESS) (KEY_FILE file | CERT_CHAIN_FILE file | RSA_KEY_FILE file | TMP_DH_FILE file | CA_CERT_FILE file | VERIFY_MODE mode* | CIPHERS (PRINT | SET ciphersuite(:ciphersuite)*))
+VHOST PAUSE vhost | UNPAUSE vhost | PRINT | BACKEND_DISCONNECT vhost | FORCE_DISCONNECT vhost
 ```
 
 


### PR DESCRIPTION
We already support VHOST config command: https://github.com/bloomberg/amqpprox#amqpprox_ctl-example-usage
And we also have the config command detail: https://github.com/bloomberg/amqpprox/blob/main/docs/config.md#vhost-commands
So we just need to add it in the initial commands list on the same page.
