### PR TITLE
Disconnect or resume unpaused connections

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -261,7 +261,7 @@ Pauses all sessions for the given `vhost`. New client connections are still acce
 
 #### VHOST UNPAUSE vhost
 
-Resumes all sessions for the given `vhost`.
+Connections for `vhost` paused during the handshake are resumed by connecting out to the appropriate broker. All other sessions for `vhost` are disconnected as though `FORCE_DISCONNECT` had been run.
 
 #### VHOST BACKEND_DISCONNECT vhost
 

--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -522,6 +522,14 @@ void Session::pause()
     }
 }
 
+void Session::unpause()
+{
+    if (d_sessionState.getPaused()) {
+        // TODO: attemptConnection if we skipped last time due to pause
+        this->disconnect(true);
+    }
+}
+
 void Session::disconnectUnauthClient(const FieldTable &clientProperties,
                                      std::string_view  reason)
 {

--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -535,7 +535,7 @@ void Session::unpause()
                 "ConnID",
                 boost::log::attributes::constant<uint64_t>(
                     d_sessionState.id()));
-            LOG_INFO << "Session unpaused. Starting to acquire connection";
+            LOG_DEBUG << "Session unpaused. Starting to acquire connection";
 
             d_sessionState.setReadyToConnectOnUnpause(false);
             d_sessionState.setPaused(false);

--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -115,6 +115,13 @@ class Session : public std::enable_shared_from_this<Session> {
     void pause();
 
     /**
+     * \brief Un-pause this session. This will disconnect the session if it was
+     * connected to the broker when paused. If the session was paused during
+     * the handshake this may in future continue the handshake.
+     */
+    void unpause();
+
+    /**
      * \brief Disconnect both sides of the session
      * \param forcible to specify forcefully disconnect
      */

--- a/libamqpprox/amqpprox_sessionstate.cpp
+++ b/libamqpprox/amqpprox_sessionstate.cpp
@@ -44,6 +44,7 @@ SessionState::SessionState(
 , d_egressLatencyTotal(0)
 , d_egressLatencyCount(0)
 , d_paused(false)
+, d_readyToConnectOnUnpause(false)
 , d_authDeniedConnection(false)
 , d_ingressSecured(false)
 , d_virtualHost()
@@ -105,6 +106,11 @@ void SessionState::setHostnameMapper(
 void SessionState::setPaused(bool paused)
 {
     d_paused = paused;
+}
+
+void SessionState::setReadyToConnectOnUnpause(bool paused)
+{
+    d_readyToConnectOnUnpause = paused;
 }
 
 void SessionState::setAuthDeniedConnection(bool authDenied)

--- a/libamqpprox/amqpprox_sessionstate.h
+++ b/libamqpprox/amqpprox_sessionstate.h
@@ -59,6 +59,7 @@ class SessionState {
     std::atomic<uint64_t>           d_ingressLatencyTotal;
     std::atomic<uint64_t>           d_egressLatencyTotal;
     std::atomic<bool>               d_paused;
+    std::atomic<bool>               d_readyToConnectOnUnpause;
     std::atomic<bool>               d_authDeniedConnection;
     std::atomic<bool>               d_ingressSecured;
     std::string                     d_virtualHost;
@@ -108,6 +109,13 @@ class SessionState {
      * \param paused flag to specify paused or unpaused virtual host
      */
     void setPaused(bool paused);
+
+    /**
+     * \brief Mark this session as ready to connect on unpause
+     * \param paused flag to specify whether unpause should trigger
+     * attemptConnection
+     */
+    void setReadyToConnectOnUnpause(bool paused);
 
     /**
      * \brief Set the denied connection flag, because of auth failure
@@ -192,6 +200,11 @@ class SessionState {
     inline bool getPaused() const;
 
     /**
+     * \return the state(paused/unpaused) of the virtual host
+     */
+    inline bool getReadyToConnectOnUnpause() const;
+
+    /**
      * \return the state of the connection, whether it is denied because of
      * auth failure
      */
@@ -249,6 +262,11 @@ inline const std::string &SessionState::getVirtualHost() const
 inline bool SessionState::getPaused() const
 {
     return d_paused;
+}
+
+inline bool SessionState::getReadyToConnectOnUnpause() const
+{
+    return d_readyToConnectOnUnpause;
 }
 
 inline bool SessionState::getAuthDeniedConnection() const

--- a/libamqpprox/amqpprox_vhostcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_vhostcontrolcommand.cpp
@@ -78,6 +78,14 @@ void VhostControlCommand::handleCommand(const std::string & /* command */,
     }
     else if (subcommand == "UNPAUSE") {
         d_vhostState_p->setPaused(vhost, false);
+
+        auto visitor = [this, &vhost](std::shared_ptr<Session> session) {
+            if (session->state().getVirtualHost() == vhost) {
+                session->unpause();
+            }
+        };
+
+        serverHandle->visitSessions(visitor);
     }
     else if (subcommand == "FORCE_DISCONNECT") {
         auto visitor = [this, &vhost](std::shared_ptr<Session> session) {


### PR DESCRIPTION
`VHOST UNPAUSE <vhost-name>` right now only permits new connections to a particularly vhost. Existing, paused, connections are left alone. This isn't exactly a problem because we are aware of this and specifically run `FORCE_DISCONNECT` where we want connections to be re-established, and heartbeats generally trigger clients to reconnect.

This patch changes the `unpause` behaviour:

1. Connections paused before the broker connection is established will be resumed without a client disconnect being required.

2. Connections paused with an open broker connection are disconnected.

Once these changes are active (specifically the first change) we can stop doing a second `FORCE_DISCONNECT` during a vhost migration:
```
VHOST PAUSE vhost-name
VHOST FORCE_DISCONNECT vhost-name
MAP FARM vhost-name <new-broker-farm>
VHOST UNPAUSE vhost-name
VHOST FORCE_DISCONNECT vhost-name
```

This is a minor improvement in migration performance / client experience. It also clarifies the meaning of `UNPAUSE` - the current behaviour is a little surprising.

Looks like these changes are being affected by a clang-format upgrade. I'll put a separate PR up for the whole project too.