### PR TITLE
Make MaybeSecureSocketAdapter::isSecure() private

### DIFF
--- a/libamqpprox/amqpprox_maybesecuresocketadaptor.h
+++ b/libamqpprox/amqpprox_maybesecuresocketadaptor.h
@@ -98,15 +98,6 @@ class MaybeSecureSocketAdaptor {
 
     boost::asio::ip::tcp::socket &socket() { return d_socket->next_layer(); }
 
-    bool isSecure()
-    {
-        if (BOOST_UNLIKELY(d_intercept.has_value())) {
-            return d_intercept.value().get().isSecure();
-        }
-
-        return d_secured && d_handshook;
-    }
-
     void setSecure(bool secure)
     {
         if (BOOST_UNLIKELY(d_intercept.has_value())) {
@@ -368,6 +359,14 @@ class MaybeSecureSocketAdaptor {
             return d_socket->next_layer().async_read_some(null_buffer,
                                                           handler);
         }
+    }
+
+  private:
+    bool isSecure()
+    {
+        // The d_handshook check exists solely because proxy protocol requires
+        // us to write to the socket outside the TLS tunnel.
+        return d_secured && d_handshook;
     }
 };
 }

--- a/libamqpprox/amqpprox_server.cpp
+++ b/libamqpprox/amqpprox_server.cpp
@@ -217,7 +217,8 @@ void Server::doAccept(int port, bool secure)
                                               &d_dnsResolver,
                                               d_hostnameMapper,
                                               d_localHostname,
-                                              d_authIntercept);
+                                              d_authIntercept,
+                                              secure);
 
                 {
                     std::lock_guard<std::mutex> lg(d_mutex);

--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -119,7 +119,8 @@ Session::Session(boost::asio::io_context               &ioContext,
                  DNSResolver                           *dnsResolver,
                  const std::shared_ptr<HostnameMapper> &hostnameMapper,
                  std::string_view                       localHostname,
-                 const std::shared_ptr<AuthInterceptInterface> &authIntercept)
+                 const std::shared_ptr<AuthInterceptInterface> &authIntercept,
+                 bool isIngressSecure)
 : d_ioContext(ioContext)
 , d_serverSocket(std::move(serverSocket))
 , d_clientSocket(std::move(clientSocket))
@@ -153,6 +154,8 @@ Session::Session(boost::asio::io_context               &ioContext,
         LOG_ERROR << "Setting options onto listening socket failed with: "
                   << ec;
     }
+
+    d_sessionState.setIngressSecured(isIngressSecure);
 }
 
 Session::~Session()
@@ -193,7 +196,6 @@ void Session::start()
     };
     d_serverSocket.async_handshake(boost::asio::ssl::stream_base::server,
                                    handshake_cb);
-    d_sessionState.setIngressSecured(this->isSecureServerSocket());
 }
 
 void Session::attemptConnection(

--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -94,7 +94,8 @@ class Session : public std::enable_shared_from_this<Session> {
             DNSResolver                                   *dnsResolver,
             const std::shared_ptr<HostnameMapper>         &hostnameMapper,
             std::string_view                               localHostname,
-            const std::shared_ptr<AuthInterceptInterface> &authIntercept);
+            const std::shared_ptr<AuthInterceptInterface> &authIntercept,
+            bool                                           isIngressSecure);
 
     ~Session();
 
@@ -315,12 +316,6 @@ class Session : public std::enable_shared_from_this<Session> {
      * message off the wire or not.
      */
     inline bool &currentlyReading(FlowType direction);
-
-    /**
-     * \return true if communication with server socket is secured, otherwise
-     * false. Represents whether clients communicate with proxy using TLS.
-     */
-    inline bool isSecureServerSocket();
 };
 
 inline MaybeSecureSocketAdaptor &Session::readSocket(FlowType direction)
@@ -416,11 +411,6 @@ inline bool &Session::currentlyReading(FlowType direction)
 {
     return direction == FlowType::INGRESS ? d_ingressCurrentlyReading
                                           : d_egressCurrentlyReading;
-}
-
-inline bool Session::isSecureServerSocket()
-{
-    return d_serverSocket.isSecure();
 }
 
 }

--- a/libamqpprox/amqpprox_socketintercept.cpp
+++ b/libamqpprox/amqpprox_socketintercept.cpp
@@ -25,11 +25,6 @@ void SocketIntercept::setSecure(bool secure)
     d_impl.setSecure(secure);
 }
 
-bool SocketIntercept::isSecure() const
-{
-    return d_impl.isSecure();
-}
-
 void SocketIntercept::refreshSocketContext()
 {
     d_impl.refreshSocketContext();

--- a/libamqpprox/amqpprox_socketintercept.h
+++ b/libamqpprox/amqpprox_socketintercept.h
@@ -75,11 +75,6 @@ class SocketIntercept {
     void setSecure(bool secure);
 
     /**
-     * \return if the socket is in secure mode
-     */
-    bool isSecure() const;
-
-    /**
      * \brief Reset the socket's context as if it is a fresh socket
      *
      * This is used to reset the context before it can be used to be accepted

--- a/libamqpprox/amqpprox_socketinterceptinterface.h
+++ b/libamqpprox/amqpprox_socketinterceptinterface.h
@@ -57,11 +57,6 @@ class SocketInterceptInterface {
     virtual void setSecure(bool secure) = 0;
 
     /**
-     * \return if the socket is in secure mode
-     */
-    virtual bool isSecure() const = 0;
-
-    /**
      * \brief Reset the socket's context as if it is a fresh socket
      *
      * This is used to reset the context before it can be used to be accepted

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -153,6 +153,11 @@ class SessionTest : public ::testing::Test {
 
     SessionTest();
 
+    std::shared_ptr<Session>
+    makeSession(MaybeSecureSocketAdaptor              &&clientSocket,
+                MaybeSecureSocketAdaptor              &&serverSocket,
+                std::shared_ptr<AuthInterceptInterface> authIntercept = 0);
+
     void driveTo(int targetStep);
 
     template <typename METH>
@@ -213,6 +218,28 @@ class SessionTest : public ::testing::Test {
         TestSocketState::State &serverState,
         TestSocketState::State &clientState);
 };
+
+std::shared_ptr<Session>
+SessionTest::makeSession(MaybeSecureSocketAdaptor              &&clientSocket,
+                         MaybeSecureSocketAdaptor              &&serverSocket,
+                         std::shared_ptr<AuthInterceptInterface> authIntercept)
+{
+    if (!authIntercept) {
+        authIntercept = d_authIntercept;
+    }
+
+    return std::make_shared<Session>(d_ioContext,
+                                     std::move(serverSocket),
+                                     std::move(clientSocket),
+                                     &d_selector,
+                                     &d_eventSource,
+                                     &d_pool,
+                                     &d_dnsResolver,
+                                     d_mapper,
+                                     LOCAL_HOSTNAME,
+                                     authIntercept,
+                                     false);
+}
 
 template <typename TYPE>
 std::vector<TYPE> filterVariant(const std::vector<Item> &items);
@@ -625,16 +652,8 @@ TEST_F(SessionTest, Connection_Then_Ping_Then_Disconnect)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -696,16 +715,8 @@ TEST_F(SessionTest, BadClientHandshake)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -759,16 +770,8 @@ TEST_F(SessionTest, BadServerHandshake)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -808,16 +811,8 @@ TEST_F(SessionTest, New_Client_Handshake_Failure)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -854,16 +849,8 @@ TEST_F(SessionTest, Connection_To_Proxy_Protocol)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -995,16 +982,8 @@ TEST_F(SessionTest, Connect_Multiple_Dns)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -1144,16 +1123,8 @@ TEST_F(SessionTest, Failover_Dns_Failure)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -1200,16 +1171,8 @@ TEST_F(SessionTest, Connection_Then_Ping_Then_Force_Disconnect)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -1256,16 +1219,8 @@ TEST_F(SessionTest, Connection_Then_Ping_Then_Backend_Disconnect)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -1341,16 +1296,8 @@ TEST_F(SessionTest, Authorized_Client_Test)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_mockAuthIntercept);
+    auto                     session = makeSession(
+        std::move(clientSocket), std::move(serverSocket), d_mockAuthIntercept);
 
     session->start();
 
@@ -1406,16 +1353,8 @@ TEST_F(
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_mockAuthIntercept);
+    auto                     session = makeSession(
+        std::move(clientSocket), std::move(serverSocket), d_mockAuthIntercept);
 
     session->start();
 
@@ -1473,16 +1412,8 @@ TEST_F(SessionTest,
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_mockAuthIntercept);
+    auto                     session = makeSession(
+        std::move(clientSocket), std::move(serverSocket), d_mockAuthIntercept);
 
     session->start();
 
@@ -1538,16 +1469,8 @@ TEST_F(SessionTest, Forward_Received_Close_Method_To_Client_During_Handshake)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -1568,16 +1491,8 @@ TEST_F(SessionTest, Close_Connection_No_Broker_Mapping)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     // Initialise the state
     d_serverState.pushItem(0, base);
@@ -1628,16 +1543,8 @@ TEST_F(SessionTest, Printing_Breathing_Test)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -1680,16 +1587,8 @@ TEST_F(SessionTest, Pause_Disconnects_Previously_Established_Connection)
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     session->start();
 
@@ -1726,16 +1625,8 @@ TEST_F(SessionTest,
 
     MaybeSecureSocketAdaptor clientSocket(d_ioContext, d_client, false);
     MaybeSecureSocketAdaptor serverSocket(d_ioContext, d_server, false);
-    auto                     session = std::make_shared<Session>(d_ioContext,
-                                             std::move(serverSocket),
-                                             std::move(clientSocket),
-                                             &d_selector,
-                                             &d_eventSource,
-                                             &d_pool,
-                                             &d_dnsResolver,
-                                             d_mapper,
-                                             LOCAL_HOSTNAME,
-                                             d_authIntercept);
+    auto                     session =
+        makeSession(std::move(clientSocket), std::move(serverSocket));
 
     // Emulate `VhostEstablishedPauser` but pause everything
     bool                    paused = false;

--- a/tests/amqpprox_socketintercepttestadaptor.cpp
+++ b/tests/amqpprox_socketintercepttestadaptor.cpp
@@ -36,12 +36,6 @@ void SocketInterceptTestAdaptor::setSecure(bool secure)
     d_state.currentState().d_secure = secure;
 }
 
-bool SocketInterceptTestAdaptor::isSecure() const
-{
-    d_state.recordCall("isSecure");
-    return d_state.currentState().d_secure;
-}
-
 void SocketInterceptTestAdaptor::refreshSocketContext()
 {
     d_state.recordCall("refreshSocketContext");

--- a/tests/amqpprox_socketintercepttestadaptor.h
+++ b/tests/amqpprox_socketintercepttestadaptor.h
@@ -79,7 +79,6 @@ class SocketInterceptTestAdaptor : public SocketInterceptInterface {
 
     // SocketInterceptInterface Implementations
     virtual void setSecure(bool secure) override;
-    virtual bool isSecure() const override;
     virtual void refreshSocketContext() override;
 
     virtual endpoint remote_endpoint(boost::system::error_code &ec) override;


### PR DESCRIPTION
This is only used for something which could happen upfront, so I moved
some things around to make this the case.

I made this change when I thought we'd want to template this class on
whether it was tls or not due to integrating with boost::beast::basic_stream,
but I've since figured out that isn't going to help us here so the next change isn't
needed. I thought this commit was still useful to tidy up the interface.