### PR TITLE
boost::asio::io_service -> boost::asio::io_context

### DIFF
--- a/amqpprox_ctl/client.m.cpp
+++ b/amqpprox_ctl/client.m.cpp
@@ -29,9 +29,9 @@ int main(int argc, char *argv[])
             return 1;
         }
 
-        boost::asio::io_service ioService;
+        boost::asio::io_context ioContext;
 
-        stream_protocol::socket clientSocket(ioService);
+        stream_protocol::socket clientSocket(ioContext);
         clientSocket.connect(stream_protocol::endpoint(argv[1]));
 
         std::string allArgs{argv[2]};

--- a/libamqpprox/amqpprox_authcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_authcontrolcommand.cpp
@@ -74,7 +74,7 @@ void AuthControlCommand::handleCommand(const std::string & /* command */,
             }
 
             serverHandle->setAuthIntercept(std::make_shared<HttpAuthIntercept>(
-                serverHandle->ioService(),
+                serverHandle->ioContext(),
                 hostname,
                 std::to_string(port),
                 target,
@@ -85,7 +85,7 @@ void AuthControlCommand::handleCommand(const std::string & /* command */,
         else if (subcommand == "ALWAYS_ALLOW") {
             serverHandle->setAuthIntercept(
                 std::make_shared<DefaultAuthIntercept>(
-                    serverHandle->ioService()));
+                    serverHandle->ioContext()));
 
             serverHandle->getAuthIntercept()->print(output);
         }

--- a/libamqpprox/amqpprox_authinterceptinterface.cpp
+++ b/libamqpprox/amqpprox_authinterceptinterface.cpp
@@ -22,8 +22,8 @@ namespace Bloomberg {
 namespace amqpprox {
 
 AuthInterceptInterface::AuthInterceptInterface(
-    boost::asio::io_service &ioService)
-: d_ioService(ioService)
+    boost::asio::io_context &ioContext)
+: d_ioContext(ioContext)
 {
 }
 

--- a/libamqpprox/amqpprox_authinterceptinterface.h
+++ b/libamqpprox/amqpprox_authinterceptinterface.h
@@ -34,7 +34,7 @@ class AuthResponse;
  */
 class AuthInterceptInterface {
   protected:
-    boost::asio::io_service &d_ioService;
+    boost::asio::io_context &d_ioContext;
 
   public:
     /**
@@ -45,7 +45,7 @@ class AuthInterceptInterface {
         ReceiveResponseCb;
 
     // CREATORS
-    explicit AuthInterceptInterface(boost::asio::io_service &ioService);
+    explicit AuthInterceptInterface(boost::asio::io_context &ioContext);
 
     virtual ~AuthInterceptInterface() = default;
 

--- a/libamqpprox/amqpprox_backendcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_backendcontrolcommand.cpp
@@ -77,8 +77,8 @@ void BackendControlCommand::handleCommand(const std::string & /* command */,
         if (!name.empty() && !datacenter.empty() && !host.empty() && port) {
             std::string ip;
             if (!isDns) {
-                auto &ioService = controlHandle->ioService();
-                boost::asio::ip::tcp::resolver        resolver(ioService);
+                auto &ioContext = controlHandle->ioContext();
+                boost::asio::ip::tcp::resolver        resolver(ioContext);
                 boost::asio::ip::tcp::resolver::query q(host, "");
                 boost::system::error_code             ec;
                 auto it = resolver.resolve(q, ec);

--- a/libamqpprox/amqpprox_control.h
+++ b/libamqpprox/amqpprox_control.h
@@ -35,7 +35,7 @@ class Server;
 class Control {
     Server                                                *d_server_p;
     EventSource                                           *d_eventSource_p;
-    boost::asio::io_service                                d_ioService;
+    boost::asio::io_context                                d_ioContext;
     boost::asio::local::stream_protocol::acceptor          d_acceptor;
     boost::asio::local::stream_protocol::socket            d_socket;
     std::map<std::string, std::unique_ptr<ControlCommand>> d_controlCommands;
@@ -91,7 +91,7 @@ class Control {
     /**
      * \return IO service for the control thread
      */
-    boost::asio::io_service &ioService();
+    boost::asio::io_context &ioContext();
 
   private:
     void doAccept();

--- a/libamqpprox/amqpprox_defaultauthintercept.cpp
+++ b/libamqpprox/amqpprox_defaultauthintercept.cpp
@@ -27,8 +27,8 @@
 namespace Bloomberg {
 namespace amqpprox {
 
-DefaultAuthIntercept::DefaultAuthIntercept(boost::asio::io_service &ioService)
-: AuthInterceptInterface(ioService)
+DefaultAuthIntercept::DefaultAuthIntercept(boost::asio::io_context &ioContext)
+: AuthInterceptInterface(ioContext)
 {
 }
 
@@ -41,7 +41,7 @@ void DefaultAuthIntercept::authenticate(const authproto::AuthRequest,
         authResponseData.set_reason("Default route auth used - always allow");
         responseCb(authResponseData);
     };
-    boost::asio::post(d_ioService, cb);
+    boost::asio::post(d_ioContext, cb);
 }
 
 void DefaultAuthIntercept::print(std::ostream &os) const

--- a/libamqpprox/amqpprox_defaultauthintercept.h
+++ b/libamqpprox/amqpprox_defaultauthintercept.h
@@ -36,7 +36,7 @@ class AuthRequest;
 class DefaultAuthIntercept : public AuthInterceptInterface {
   public:
     // CREATORS
-    explicit DefaultAuthIntercept(boost::asio::io_service &ioService);
+    explicit DefaultAuthIntercept(boost::asio::io_context &ioContext);
 
     virtual ~DefaultAuthIntercept() override = default;
 

--- a/libamqpprox/amqpprox_dnshostnamemapper.cpp
+++ b/libamqpprox/amqpprox_dnshostnamemapper.cpp
@@ -37,10 +37,10 @@ DNSHostnameMapper::DNSHostnameMapper()
 }
 
 void DNSHostnameMapper::prime(
-    boost::asio::io_service                              &ioService,
+    boost::asio::io_context                              &ioContext,
     std::initializer_list<boost::asio::ip::tcp::endpoint> endpoints)
 {
-    boost::asio::ip::tcp::resolver resolver(ioService);
+    boost::asio::ip::tcp::resolver resolver(ioContext);
     for (const auto &endpoint : endpoints) {
         auto address = boost::lexical_cast<std::string>(endpoint.address());
         boost::upgrade_lock<boost::shared_mutex> lock(d_lg);

--- a/libamqpprox/amqpprox_dnshostnamemapper.h
+++ b/libamqpprox/amqpprox_dnshostnamemapper.h
@@ -39,10 +39,10 @@ class DNSHostnameMapper : public HostnameMapper {
 
     /**
      * \brief prime the cache of hostnames with a list of endpoints
-     * \param ioService handle to the boost asio service
+     * \param ioContext handle to the boost asio service
      * \param endpoints list of endpoints to prime the cache with
      */
-    void prime(boost::asio::io_service                              &ioService,
+    void prime(boost::asio::io_context                              &ioContext,
                std::initializer_list<boost::asio::ip::tcp::endpoint> endpoints)
         override;
 

--- a/libamqpprox/amqpprox_dnsresolver.cpp
+++ b/libamqpprox/amqpprox_dnsresolver.cpp
@@ -29,10 +29,10 @@ namespace amqpprox {
 
 DNSResolver::OverrideFunction DNSResolver::s_override;
 
-DNSResolver::DNSResolver(boost::asio::io_service &ioService)
-: d_ioService(ioService)
-, d_resolver(d_ioService)
-, d_timer(d_ioService)
+DNSResolver::DNSResolver(boost::asio::io_context &ioContext)
+: d_ioContext(ioContext)
+, d_resolver(d_ioContext)
+, d_timer(d_ioContext)
 , d_cacheTimeout(1000)
 , d_cacheTimerRunning(false)
 {

--- a/libamqpprox/amqpprox_dnsresolver.h
+++ b/libamqpprox/amqpprox_dnsresolver.h
@@ -62,7 +62,7 @@ class DNSResolver {
                                                 const std::string &)>;
 
   private:
-    boost::asio::io_service       &d_ioService;
+    boost::asio::io_context       &d_ioContext;
     boost::asio::ip::tcp::resolver d_resolver;
     boost::asio::steady_timer      d_timer;
     std::atomic<uint32_t>          d_cacheTimeout;
@@ -74,11 +74,11 @@ class DNSResolver {
 
   public:
     /**
-     * \brief Construct a resolver using io_service
+     * \brief Construct a resolver using io_context
      *
-     * This resolver will then use the passed io_service as its event loop.
+     * This resolver will then use the passed io_context as its event loop.
      */
-    explicit DNSResolver(boost::asio::io_service &ioService);
+    explicit DNSResolver(boost::asio::io_context &ioContext);
 
     ~DNSResolver();
 
@@ -192,7 +192,7 @@ void DNSResolver::resolve(std::string_view       query_host,
             boost::system::error_code ec;
             std::vector<TcpEndpoint>  result = it->second;
             auto cb = [callback, ec, result] { callback(ec, result); };
-            d_ioService.post(cb);
+            d_ioContext.post(cb);
             return;
         }
     }
@@ -203,7 +203,7 @@ void DNSResolver::resolve(std::string_view       query_host,
         LOG_TRACE << "Returning " << vec.size()
                   << " overriden values with ec = " << ec;
         auto cb = [callback, ec, vec] { callback(ec, vec); };
-        d_ioService.post(cb);
+        d_ioContext.post(cb);
 
         if (!ec) {
             setCachedResolution(host, service, std::move(vec));

--- a/libamqpprox/amqpprox_hostnamemapper.h
+++ b/libamqpprox/amqpprox_hostnamemapper.h
@@ -30,11 +30,11 @@ class HostnameMapper {
 
     /**
      * \brief prime the cache of hostnames with a list of endpoints
-     * \param ioService handle to the boost asio service
+     * \param ioContext handle to the boost asio service
      * \param endpoints list of endpoints to prime the cache with
      */
     virtual void
-    prime(boost::asio::io_service                              &ioService,
+    prime(boost::asio::io_context                              &ioContext,
           std::initializer_list<boost::asio::ip::tcp::endpoint> endpoint) = 0;
 
     /**

--- a/libamqpprox/amqpprox_httpauthintercept.cpp
+++ b/libamqpprox/amqpprox_httpauthintercept.cpp
@@ -41,13 +41,13 @@ const int TIMEOUT_SECONDS = 30;
 int       HTTP_VERSION    = 11;  // HTTP/1.1 version
 }
 
-HttpAuthIntercept::HttpAuthIntercept(boost::asio::io_service &ioService,
+HttpAuthIntercept::HttpAuthIntercept(boost::asio::io_context &ioContext,
                                      const std::string       &hostname,
                                      const std::string       &port,
                                      const std::string       &target,
                                      DNSResolver             *dnsResolver)
-: AuthInterceptInterface(ioService)
-, d_ioService(ioService)
+: AuthInterceptInterface(ioContext)
+, d_ioContext(ioContext)
 , d_hostname(hostname)
 , d_port(port)
 , d_target(target)
@@ -115,7 +115,7 @@ void HttpAuthIntercept::onResolve(
 
     std::shared_ptr<beast::tcp_stream> stream =
         std::make_shared<beast::tcp_stream>(
-            boost::asio::make_strand(d_ioService));
+            boost::asio::make_strand(d_ioContext));
     // Set a timeout on the operation
     stream->expires_after(std::chrono::seconds(TIMEOUT_SECONDS));
 

--- a/libamqpprox/amqpprox_httpauthintercept.h
+++ b/libamqpprox/amqpprox_httpauthintercept.h
@@ -36,7 +36,7 @@ class HttpAuthIntercept
   public std::enable_shared_from_this<HttpAuthIntercept> {
     using tcp = boost::asio::ip::tcp;
 
-    boost::asio::io_service &d_ioService;
+    boost::asio::io_context &d_ioContext;
     std::string              d_hostname;
     std::string              d_port;
     std::string              d_target;
@@ -70,7 +70,7 @@ class HttpAuthIntercept
 
   public:
     // CREATORS
-    HttpAuthIntercept(boost::asio::io_service &ioService,
+    HttpAuthIntercept(boost::asio::io_context &ioContext,
                       const std::string       &hostname,
                       const std::string       &port,
                       const std::string       &target,

--- a/libamqpprox/amqpprox_maphostnamecontrolcommand.cpp
+++ b/libamqpprox/amqpprox_maphostnamecontrolcommand.cpp
@@ -62,7 +62,7 @@ void MapHostnameControlCommand::handleCommand(
     serverHandle->setHostnameMapper(m);
     serverHandle->visitSessions(
         [&m, controlHandle](const std::shared_ptr<Session> &s) {
-            s->state().setHostnameMapper(controlHandle->ioService(), m);
+            s->state().setHostnameMapper(controlHandle->ioContext(), m);
         });
 
     outputFunctor("Hostname mapper set for all current sessions.\n", true);

--- a/libamqpprox/amqpprox_maybesecuresocketadaptor.h
+++ b/libamqpprox/amqpprox_maybesecuresocketadaptor.h
@@ -41,7 +41,7 @@ class MaybeSecureSocketAdaptor {
     using endpoint    = boost::asio::ip::tcp::endpoint;
     using handshake_type = boost::asio::ssl::stream_base::handshake_type;
 
-    boost::asio::io_service                               &d_ioService;
+    boost::asio::io_context                               &d_ioService;
     std::optional<std::reference_wrapper<SocketIntercept>> d_intercept;
     std::unique_ptr<stream_type>                           d_socket;
     bool                                                   d_secured;
@@ -53,7 +53,7 @@ class MaybeSecureSocketAdaptor {
     typedef typename stream_type::executor_type executor_type;
 
 #ifdef SOCKET_TESTING
-    MaybeSecureSocketAdaptor(boost::asio::io_service &ioService,
+    MaybeSecureSocketAdaptor(boost::asio::io_context &ioService,
                              SocketIntercept         &intercept,
                              bool                     secured)
     : d_ioService(ioService)
@@ -67,7 +67,7 @@ class MaybeSecureSocketAdaptor {
     }
 #endif
 
-    MaybeSecureSocketAdaptor(boost::asio::io_service   &ioService,
+    MaybeSecureSocketAdaptor(boost::asio::io_context   &ioService,
                              boost::asio::ssl::context &context,
                              bool                       secured)
     : d_ioService(ioService)

--- a/libamqpprox/amqpprox_server.h
+++ b/libamqpprox/amqpprox_server.h
@@ -44,7 +44,7 @@ class HostnameMapper;
 class Server {
     using SessionPtr = std::shared_ptr<Session>;
 
-    boost::asio::io_service                  d_ioService;
+    boost::asio::io_context                  d_ioContext;
     boost::asio::ssl::context                d_ingressTlsContext;
     boost::asio::ssl::context                d_egressTlsContext;
     boost::asio::deadline_timer              d_timer;
@@ -162,7 +162,7 @@ class Server {
     /**
      * \return the boost::asio io service object
      */
-    boost::asio::io_service &ioService();
+    boost::asio::io_context &ioContext();
 
     /**
      * \return the current AuthIntercept mechanism applied on each session

--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -57,7 +57,7 @@ class Session : public std::enable_shared_from_this<Session> {
     using TimePoint =
         std::chrono::time_point<std::chrono::high_resolution_clock>;
 
-    boost::asio::io_service     &d_ioService;
+    boost::asio::io_context     &d_ioContext;
     MaybeSecureSocketAdaptor     d_serverSocket;
     MaybeSecureSocketAdaptor     d_clientSocket;
     BufferHandle                 d_serverDataHandle;
@@ -85,7 +85,7 @@ class Session : public std::enable_shared_from_this<Session> {
 
   public:
     // CREATORS
-    Session(boost::asio::io_service                       &ioservice,
+    Session(boost::asio::io_context                       &ioContext,
             MaybeSecureSocketAdaptor                     &&serverSocket,
             MaybeSecureSocketAdaptor                     &&clientSocket,
             ConnectionSelectorInterface                   *connectionSelector,

--- a/libamqpprox/amqpprox_sessionstate.cpp
+++ b/libamqpprox/amqpprox_sessionstate.cpp
@@ -55,12 +55,12 @@ SessionState::SessionState(
 {
 }
 
-void SessionState::setEgress(boost::asio::io_service       &ioService,
+void SessionState::setEgress(boost::asio::io_context       &ioContext,
                              boost::asio::ip::tcp::endpoint local,
                              boost::asio::ip::tcp::endpoint remote)
 {
     if (d_hostnameMapper) {
-        d_hostnameMapper->prime(ioService, {local, remote});
+        d_hostnameMapper->prime(ioContext, {local, remote});
     }
 
     std::lock_guard<std::mutex> lg(d_lock);
@@ -68,12 +68,12 @@ void SessionState::setEgress(boost::asio::io_service       &ioService,
     d_egressRemoteEndpoint = remote;
 }
 
-void SessionState::setIngress(boost::asio::io_service       &ioService,
+void SessionState::setIngress(boost::asio::io_context       &ioContext,
                               boost::asio::ip::tcp::endpoint local,
                               boost::asio::ip::tcp::endpoint remote)
 {
     if (d_hostnameMapper) {
-        d_hostnameMapper->prime(ioService, {local, remote});
+        d_hostnameMapper->prime(ioContext, {local, remote});
     }
 
     std::lock_guard<std::mutex> lg(d_lock);
@@ -88,7 +88,7 @@ void SessionState::setVirtualHost(const std::string &vhost)
 }
 
 void SessionState::setHostnameMapper(
-    boost::asio::io_service               &ioService,
+    boost::asio::io_context               &ioContext,
     const std::shared_ptr<HostnameMapper> &hostnameMapper)
 {
     if (!hostnameMapper) {
@@ -96,7 +96,7 @@ void SessionState::setHostnameMapper(
     }
     std::lock_guard<std::mutex> lg(d_lock);
     d_hostnameMapper = hostnameMapper;
-    d_hostnameMapper->prime(ioService,
+    d_hostnameMapper->prime(ioContext,
                             {d_ingressLocalEndpoint,
                              d_ingressRemoteEndpoint,
                              d_egressLocalEndpoint,

--- a/libamqpprox/amqpprox_sessionstate.h
+++ b/libamqpprox/amqpprox_sessionstate.h
@@ -87,21 +87,21 @@ class SessionState {
     // MANIPULATORS
     /**
      * \brief Set the tcp pair for egress
-     * \param ioService handle to the boost asio service
+     * \param ioContext handle to the boost asio service
      * \param local local endpoint
      * \param remote remote endpoint
      */
-    void setEgress(boost::asio::io_service       &ioService,
+    void setEgress(boost::asio::io_context       &ioContext,
                    boost::asio::ip::tcp::endpoint local,
                    boost::asio::ip::tcp::endpoint remote);
 
     /**
      * \brief Set the tcp pair for ingress
-     * \param ioService handle to the boost asio service
+     * \param ioContext handle to the boost asio service
      * \param local local endpoint
      * \param remote remote endpoint
      */
-    void setIngress(boost::asio::io_service       &ioService,
+    void setIngress(boost::asio::io_context       &ioContext,
                     boost::asio::ip::tcp::endpoint local,
                     boost::asio::ip::tcp::endpoint remote);
 
@@ -146,11 +146,11 @@ class SessionState {
 
     /**
      * \brief Set up a hostname mapper for the Session
-     * \param ioService handle to the boost asio service
+     * \param ioContext handle to the boost asio service
      * \param hostnameMapper shared pointer to `HostnameMapper`
      */
     void
-    setHostnameMapper(boost::asio::io_service               &ioService,
+    setHostnameMapper(boost::asio::io_context               &ioContext,
                       const std::shared_ptr<HostnameMapper> &hostnameMapper);
 
     /**

--- a/libamqpprox/amqpprox_statcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_statcontrolcommand.cpp
@@ -294,7 +294,7 @@ void StatControlCommand::handleCommand(const std::string   &command,
         }
         std::shared_ptr<StatsDPublisher> publisher =
             std::make_shared<StatsDPublisher>(
-                &controlHandle->ioService(), outputHost, outputPort);
+                &controlHandle->ioContext(), outputHost, outputPort);
         StatFunctor sf = [publisher](const StatSnapshot &statSnapshot) {
             publisher->publish(statSnapshot);
             return true;

--- a/libamqpprox/amqpprox_statsdpublisher.cpp
+++ b/libamqpprox/amqpprox_statsdpublisher.cpp
@@ -58,13 +58,13 @@ formatMetric(MetricType                                              type,
 
 }
 
-StatsDPublisher::StatsDPublisher(boost::asio::io_service *ioService,
+StatsDPublisher::StatsDPublisher(boost::asio::io_context *ioContext,
                                  const std::string       &host,
                                  int                      port)
-: d_socket(*ioService,
+: d_socket(*ioContext,
            boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0))
 {
-    boost::asio::ip::udp::resolver        resolver(*ioService);
+    boost::asio::ip::udp::resolver        resolver(*ioContext);
     boost::asio::ip::udp::resolver::query query(
         boost::asio::ip::udp::v4(), host, std::to_string(port));
     d_statsdEndpoint = *resolver.resolve(query);

--- a/libamqpprox/amqpprox_statsdpublisher.h
+++ b/libamqpprox/amqpprox_statsdpublisher.h
@@ -41,7 +41,7 @@ class StatsDPublisher {
 
   public:
     // CREATORS
-    StatsDPublisher(boost::asio::io_service *ioService,
+    StatsDPublisher(boost::asio::io_context *ioContext,
                     const std::string       &host,
                     int                      port);
 

--- a/tests/amqpprox_defaultauthintercept.t.cpp
+++ b/tests/amqpprox_defaultauthintercept.t.cpp
@@ -31,29 +31,29 @@ using Bloomberg::amqpprox::DefaultAuthIntercept;
 
 TEST(DefaultAuthIntercept, Breathing)
 {
-    boost::asio::io_service ioService;
-    DefaultAuthIntercept    defaultAuth(ioService);
-    ioService.run();
+    boost::asio::io_context ioContext;
+    DefaultAuthIntercept    defaultAuth(ioContext);
+    ioContext.run();
 }
 
 TEST(DefaultAuthIntercept, Authenticate)
 {
-    boost::asio::io_service ioService;
-    DefaultAuthIntercept    defaultAuth(ioService);
+    boost::asio::io_context ioContext;
+    DefaultAuthIntercept    defaultAuth(ioContext);
     auto responseCb = [](const authproto::AuthResponse &authResponseData) {
         ASSERT_EQ(authResponseData.result(), authproto::AuthResponse::ALLOW);
         ASSERT_EQ(authResponseData.reason(),
                   "Default route auth used - always allow");
     };
     defaultAuth.authenticate(authproto::AuthRequest(), responseCb);
-    ioService.run();
+    ioContext.run();
 }
 
 TEST(DefaultAuthIntercept, Print)
 {
-    boost::asio::io_service ioService;
-    DefaultAuthIntercept    defaultAuth(ioService);
-    ioService.run();
+    boost::asio::io_context ioContext;
+    DefaultAuthIntercept    defaultAuth(ioContext);
+    ioContext.run();
     std::ostringstream oss;
     defaultAuth.print(oss);
     EXPECT_EQ(oss.str(),

--- a/tests/amqpprox_dnsresolver.t.cpp
+++ b/tests/amqpprox_dnsresolver.t.cpp
@@ -29,18 +29,18 @@ using namespace testing;
 
 TEST(DNSResolver, Breathing)
 {
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
-    ioService.run();
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
+    ioContext.run();
 }
 
 TEST(DNSResolver, StartStopCleanup)
 {
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
     resolver.startCleanupTimer();
     resolver.stopCleanupTimer();
-    ioService.run();
+    ioContext.run();
 }
 
 struct MockDnsResolver {
@@ -72,8 +72,8 @@ TEST(DNSResolver, Override_And_Return)
                                                std::placeholders::_2,
                                                std::placeholders::_3));
 
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
     resolver.startCleanupTimer();
     auto cb = [local_ipv4,
                local_ipv6](const boost::system::error_code &ec,
@@ -84,7 +84,7 @@ TEST(DNSResolver, Override_And_Return)
     };
     resolver.resolve("test1", "5672", cb);
     resolver.stopCleanupTimer();
-    ioService.run();
+    ioContext.run();
 
     DNSResolver::setOverrideFunction(DNSResolver::OverrideFunction());
 }
@@ -110,8 +110,8 @@ TEST(DNSResolver, Cache_Removes_Multiple_Resolutions)
                                                std::placeholders::_2,
                                                std::placeholders::_3));
 
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
     resolver.startCleanupTimer();
     auto cb = [local_ipv4,
                local_ipv6](const boost::system::error_code &ec,
@@ -126,7 +126,7 @@ TEST(DNSResolver, Cache_Removes_Multiple_Resolutions)
     resolver.resolve("test1", "5672", cb);
     resolver.resolve("test1", "5672", cb);
     resolver.stopCleanupTimer();
-    ioService.run();
+    ioContext.run();
 
     DNSResolver::setOverrideFunction(DNSResolver::OverrideFunction());
 }
@@ -154,8 +154,8 @@ TEST(DNSResolver, Multiple_Resolutions_Needed_After_Cache_Cleanup)
                                                std::placeholders::_2,
                                                std::placeholders::_3));
 
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
     auto                    cb = [local_ipv4,
                local_ipv6](const boost::system::error_code &ec,
                            const std::vector<TcpEndpoint> & endpoints) {
@@ -171,12 +171,12 @@ TEST(DNSResolver, Multiple_Resolutions_Needed_After_Cache_Cleanup)
     // the chance
     resolver.setCacheTimeout(1);
     resolver.startCleanupTimer();
-    ioService.run_for(50ms);
+    ioContext.run_for(50ms);
 
     // Second request should be cache cold, so expectation is 2 times
     resolver.resolve("test1", "5672", cb);
     resolver.stopCleanupTimer();
-    ioService.run();
+    ioContext.run();
 
     DNSResolver::setOverrideFunction(DNSResolver::OverrideFunction());
 }
@@ -212,8 +212,8 @@ TEST(DNSResolver, Independent_Resolutions_Get_Cached_Indpendently)
                                                std::placeholders::_2,
                                                std::placeholders::_3));
 
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
     resolver.startCleanupTimer();
     auto cb1 = [local_ipv4,
                 local_ipv6](const boost::system::error_code &ec,
@@ -236,7 +236,7 @@ TEST(DNSResolver, Independent_Resolutions_Get_Cached_Indpendently)
     resolver.resolve("test2", "5673", cb2);
     resolver.resolve("test2", "5673", cb2);
     resolver.stopCleanupTimer();
-    ioService.run();
+    ioContext.run();
 
     DNSResolver::setOverrideFunction(DNSResolver::OverrideFunction());
 }
@@ -258,8 +258,8 @@ TEST(DNSResolver, No_Underlying_Call_When_Cached)
                                                std::placeholders::_2,
                                                std::placeholders::_3));
 
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
     resolver.startCleanupTimer();
     auto cb1 = [local_ipv4,
                 local_ipv6](const boost::system::error_code &ec,
@@ -273,7 +273,7 @@ TEST(DNSResolver, No_Underlying_Call_When_Cached)
     resolver.resolve("test1", "5672", cb1);
     resolver.resolve("test1", "5672", cb1);
     resolver.stopCleanupTimer();
-    ioService.run();
+    ioContext.run();
 
     DNSResolver::setOverrideFunction(DNSResolver::OverrideFunction());
 }
@@ -299,8 +299,8 @@ TEST(DNSResolver, Cache_Clear_Means_Multiple_Resolutions)
                                                std::placeholders::_2,
                                                std::placeholders::_3));
 
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
     resolver.startCleanupTimer();
     auto cb = [local_ipv4,
                local_ipv6](const boost::system::error_code &ec,
@@ -316,7 +316,7 @@ TEST(DNSResolver, Cache_Clear_Means_Multiple_Resolutions)
     resolver.clearCachedResolution("test1", "5672");
     resolver.resolve("test1", "5672", cb);
     resolver.stopCleanupTimer();
-    ioService.run();
+    ioContext.run();
 
     DNSResolver::setOverrideFunction(DNSResolver::OverrideFunction());
 }
@@ -327,8 +327,8 @@ TEST(DNSResolver, Real_Resolver_For_IP)
     std::vector<TcpEndpoint> resolveResult;
     resolveResult.push_back(local_ipv4);
 
-    boost::asio::io_service ioService;
-    DNSResolver             resolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             resolver(ioContext);
     resolver.startCleanupTimer();
     auto cb = [local_ipv4](const boost::system::error_code &ec,
                            const std::vector<TcpEndpoint> & endpoints) {
@@ -338,5 +338,5 @@ TEST(DNSResolver, Real_Resolver_For_IP)
     };
     resolver.resolve("127.0.0.1", "5672", cb);
     resolver.stopCleanupTimer();
-    ioService.run();
+    ioContext.run();
 }

--- a/tests/amqpprox_httpauthintercept.t.cpp
+++ b/tests/amqpprox_httpauthintercept.t.cpp
@@ -28,20 +28,20 @@ using Bloomberg::amqpprox::HttpAuthIntercept;
 
 TEST(HttpAuthIntercept, Breathing)
 {
-    boost::asio::io_service ioService;
-    DNSResolver             dnsResolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             dnsResolver(ioContext);
     HttpAuthIntercept       authIntercept(
-        ioService, "localhost", "8080", "/target", &dnsResolver);
-    ioService.run();
+        ioContext, "localhost", "8080", "/target", &dnsResolver);
+    ioContext.run();
 }
 
 TEST(HttpAuthIntercept, Print)
 {
-    boost::asio::io_service ioService;
-    DNSResolver             dnsResolver(ioService);
+    boost::asio::io_context ioContext;
+    DNSResolver             dnsResolver(ioContext);
     HttpAuthIntercept       authIntercept(
-        ioService, "localhost", "8080", "/target", &dnsResolver);
-    ioService.run();
+        ioContext, "localhost", "8080", "/target", &dnsResolver);
+    ioContext.run();
     std::ostringstream oss;
     authIntercept.print(oss);
     EXPECT_EQ(oss.str(),

--- a/tests/amqpprox_sessionstate.t.cpp
+++ b/tests/amqpprox_sessionstate.t.cpp
@@ -32,7 +32,7 @@ class MockHostnameMapper : public HostnameMapper {
   public:
     MOCK_METHOD2(
         prime,
-        void(boost::asio::io_service &ioService,
+        void(boost::asio::io_context &ioContext,
              const std::initializer_list<boost::asio::ip::tcp::endpoint>
                  endpoint));
     MOCK_CONST_METHOD1(
@@ -44,7 +44,7 @@ class MockHostnameMapper : public HostnameMapper {
 
 TEST(SessionState, noHostnameMapper)
 {
-    io_service ioService;
+    io_context ioContext;
 
     SessionState s(nullptr);
 
@@ -52,7 +52,7 @@ TEST(SessionState, noHostnameMapper)
     auto ip2  = "2.2.2.2";
     auto port = 42;
 
-    s.setEgress(ioService,
+    s.setEgress(ioContext,
                 ip::tcp::endpoint(ip::address::from_string(ip1), port),
                 ip::tcp::endpoint(ip::address::from_string(ip2), port));
 
@@ -63,7 +63,7 @@ TEST(SessionState, noHostnameMapper)
 
 TEST(SessionState, hostnameMapper)
 {
-    io_service ioService;
+    io_context ioContext;
 
     auto         m = std::make_shared<MockHostnameMapper>();
     SessionState s(m);
@@ -73,7 +73,7 @@ TEST(SessionState, hostnameMapper)
     auto port = 42;
 
     EXPECT_CALL(*m, prime(_, _)).Times(1);
-    s.setEgress(ioService,
+    s.setEgress(ioContext,
                 ip::tcp::endpoint(ip::address::from_string(ip1), port),
                 ip::tcp::endpoint(ip::address::from_string(ip2), port));
 


### PR DESCRIPTION
io_service is a deprecated name, I think asio renamed this as part of aligning with the networking TS (possibly coming in C++23? who knows). This likely isn't the only thing which changed, but it stands out when reading the codebase. https://www.boost.org/doc/libs/1_79_0/doc/html/boost_asio/net_ts.html is a reference if anyone's interested