### PR TITLE
Remove usage of anonymous namespace in header file

### DIFF
--- a/libamqpprox/amqpprox_httpauthintercept.cpp
+++ b/libamqpprox/amqpprox_httpauthintercept.cpp
@@ -36,7 +36,6 @@ namespace amqpprox {
 
 namespace {
 namespace beast = boost::beast;
-using tcp       = boost::asio::ip::tcp;
 
 const int TIMEOUT_SECONDS = 30;
 int       HTTP_VERSION    = 11;  // HTTP/1.1 version
@@ -210,7 +209,7 @@ void HttpAuthIntercept::onWrite(
 }
 
 void HttpAuthIntercept::onRead(
-    std::shared_ptr<beast::flat_buffer>,  // Buffer must persists between reads
+    std::shared_ptr<beast::flat_buffer>,  // Buffer must persist between reads
     std::shared_ptr<beast::tcp_stream>                               stream,
     std::shared_ptr<beast::http::response<beast::http::string_body>> response,
     const ReceiveResponseCb &responseCb,

--- a/libamqpprox/amqpprox_httpauthintercept.h
+++ b/libamqpprox/amqpprox_httpauthintercept.h
@@ -31,14 +31,11 @@
 namespace Bloomberg {
 namespace amqpprox {
 
-namespace {
-namespace beast = boost::beast;
-using tcp       = boost::asio::ip::tcp;
-}
-
 class HttpAuthIntercept
 : public AuthInterceptInterface,
   public std::enable_shared_from_this<HttpAuthIntercept> {
+    using tcp = boost::asio::ip::tcp;
+
     boost::asio::io_service &d_ioService;
     std::string              d_hostname;
     std::string              d_port;
@@ -46,34 +43,30 @@ class HttpAuthIntercept
     DNSResolver             *d_dnsResolver_p;
     mutable std::mutex       d_mutex;
 
-    void
-    onResolve(std::shared_ptr<beast::http::request<beast::http::string_body>>
-                                               request,
-              const ReceiveResponseCb         &responseCb,
-              const boost::system::error_code &ec,
-              std::vector<tcp::endpoint>       results);
-    void
-    onConnect(std::shared_ptr<beast::tcp_stream> stream,
-              std::shared_ptr<beast::http::request<beast::http::string_body>>
-                                       request,
-              const ReceiveResponseCb &responseCb,
-              beast::error_code        ec,
-              tcp::resolver::results_type::endpoint_type);
-    void
-    onWrite(std::shared_ptr<beast::tcp_stream> stream,
-            std::shared_ptr<beast::http::request<beast::http::string_body>>
-                                     request,
-            const ReceiveResponseCb &responseCb,
-            beast::error_code        ec,
-            std::size_t              bytes_transferred);
-    void
-    onRead(std::shared_ptr<beast::flat_buffer> buffer,
-           std::shared_ptr<beast::tcp_stream>  stream,
-           std::shared_ptr<beast::http::response<beast::http::string_body>>
-                                    response,
-           const ReceiveResponseCb &responseCb,
-           beast::error_code        ec,
-           std::size_t              bytes_transferred);
+    void onResolve(std::shared_ptr<boost::beast::http::request<
+                       boost::beast::http::string_body>> request,
+                   const ReceiveResponseCb              &responseCb,
+                   const boost::system::error_code      &ec,
+                   std::vector<tcp::endpoint>            results);
+    void onConnect(std::shared_ptr<boost::beast::tcp_stream> stream,
+                   std::shared_ptr<boost::beast::http::request<
+                       boost::beast::http::string_body>>     request,
+                   const ReceiveResponseCb                  &responseCb,
+                   boost::beast::error_code                  ec,
+                   tcp::resolver::results_type::endpoint_type);
+    void onWrite(std::shared_ptr<boost::beast::tcp_stream> stream,
+                 std::shared_ptr<boost::beast::http::request<
+                     boost::beast::http::string_body>>     request,
+                 const ReceiveResponseCb                  &responseCb,
+                 boost::beast::error_code                  ec,
+                 std::size_t                               bytes_transferred);
+    void onRead(std::shared_ptr<boost::beast::flat_buffer> buffer,
+                std::shared_ptr<boost::beast::tcp_stream>  stream,
+                std::shared_ptr<boost::beast::http::response<
+                    boost::beast::http::string_body>>      response,
+                const ReceiveResponseCb                   &responseCb,
+                boost::beast::error_code                   ec,
+                std::size_t                                bytes_transferred);
 
   public:
     // CREATORS


### PR DESCRIPTION
There aren't many benefits of this, and the behaviour of anonymous namespaces in header files isn't obvious. This has caused some issues for us in the past. Cleaning up for an internal ticket