### PR TITLE
Limit reason field to 255 characters in authResponse, while sending close method to amqp clients

### DIFF
--- a/authproto/README.md
+++ b/authproto/README.md
@@ -14,7 +14,7 @@ The service will receive POST request from amqpprox proxy with following fields 
 ### Response
 The service should respond to amqpprox proxy with following fields in [protobuf format](./authresponse.proto)
 - Auth Result - This will decide, whether to allow or deny clients. It is a enum type, takes ALLOW or DENY value only.
-- Reason - Reason for the returned auth result. It is an optional field, but good to specify.
+- Reason - Reason for the returned auth result. It is an optional field, but good to specify. The reason(reply-text) field is defined as short string in AMQP 0.9.1 protocol implementation. So it will be truncated before sending to the amqp clients, if the size of the string is more than 255 characters.
 - SASL auth data - It is an optional field. In case of absence, the START-OK AMQP connection method, received from clients will be sent to the broker without any modification during handshake.
     - Broker mechanism - Authentication mechanism field for START-OK AMQP connection method. This will be injected into START-OK AMQP connection method to send to the broker during handshake. E.g. PLAIN
     - Credentials - Response field for START-OK AMQP connection method. This will also be injectd into START-OK AMQP connection method to send to the broker during handshake. E.g.'\0user\0password'

--- a/authproto/authresponse.proto
+++ b/authproto/authresponse.proto
@@ -26,6 +26,8 @@ message AuthResponse {
         DENY = 1;
     }
     AuthResult result = 1;
+
+    // Maximum 255 characters
     string reason = 2;
     SASL authData = 3;
 }

--- a/libamqpprox/amqpprox_constants.h
+++ b/libamqpprox/amqpprox_constants.h
@@ -97,6 +97,8 @@ class Constants {
     {
         return "authentication_failure_close";
     }
+
+    static constexpr std::size_t shortStringLimit() { return 255; }
 };
 
 }

--- a/libamqpprox/amqpprox_types.cpp
+++ b/libamqpprox/amqpprox_types.cpp
@@ -16,6 +16,7 @@
 #include <amqpprox_types.h>
 
 #include <amqpprox_buffer.h>
+#include <amqpprox_constants.h>
 #include <amqpprox_fieldtable.h>
 #include <amqpprox_fieldvalue.h>
 #include <amqpprox_logging.h>
@@ -86,7 +87,7 @@ bool Types::encodeShortString(Buffer &buffer, const std::string &string)
         return false;
     }
 
-    if (string.size() > 255) {
+    if (string.size() > Constants::shortStringLimit()) {
         return false;
     }
 


### PR DESCRIPTION
At the moment, we are not restricting reason field in authResponse protobuf, while communicating with external service to authenticate clients. Because of that if the external service sends more than 255 characters in reason field, the amqpprox will not be able to encode the Close connection method properly and will not be able to send the Close method to amqp client. The Close connection method's reason(reply-text) field is defined as short string(not more than 255 characters) in the AMQP 0.9.1 protocol. So this PR actively limit the number of characters in the reason field. And in this way, the client will at-least get the close method, otherwise amqpprox restrict that method from sending because of 255 characters limit.
