### PR TITLE
Add support to provide zero connection rate limit

### DIFF
--- a/libamqpprox/amqpprox_connectionlimitermanager.h
+++ b/libamqpprox/amqpprox_connectionlimitermanager.h
@@ -18,9 +18,9 @@
 
 #include <amqpprox_connectionlimiterinterface.h>
 
-#include <iostream>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -58,9 +58,9 @@ class ConnectionLimiterManager {
     ConnectionLimiters d_connectionRateLimitersPerVhost;
     ConnectionLimiters d_alarmOnlyConnectionRateLimitersPerVhost;
 
-    uint32_t           d_defaultConnectionRateLimit;
-    uint32_t           d_defaultAlarmOnlyConnectionRateLimit;
-    mutable std::mutex d_mutex;
+    std::optional<uint32_t> d_defaultConnectionRateLimit;
+    std::optional<uint32_t> d_defaultAlarmOnlyConnectionRateLimit;
+    mutable std::mutex      d_mutex;
 
   public:
     // CREATORS
@@ -142,6 +142,11 @@ class ConnectionLimiterManager {
      */
     bool allowNewConnectionForVhost(const std::string &vhostName);
 
+    /**
+     * \brief Called when a session is marked as disconnected.
+     */
+    void sessionClosedForVhost(const std::string &vhostName);
+
     // ACCESSORS
     /**
      * \brief Get particular connection rate limiter based on specified vhost
@@ -162,13 +167,13 @@ class ConnectionLimiterManager {
      * \brief Get default connection rate limit (allowed connections per
      * second) for all the connecting vhosts
      */
-    uint32_t getDefaultConnectionRateLimit() const;
+    std::optional<uint32_t> getDefaultConnectionRateLimit() const;
 
     /**
-     * \brief Get alarm onlt default connection rate limit (allowed connections
+     * \brief Get alarm only default connection rate limit (allowed connections
      * per second) for all the connecting vhosts
      */
-    uint32_t getAlarmOnlyDefaultConnectionRateLimit() const;
+    std::optional<uint32_t> getAlarmOnlyDefaultConnectionRateLimit() const;
 };
 
 }

--- a/libamqpprox/amqpprox_fixedwindowconnectionratelimiter.cpp
+++ b/libamqpprox/amqpprox_fixedwindowconnectionratelimiter.cpp
@@ -20,7 +20,6 @@
 
 #include <chrono>
 #include <memory>
-#include <mutex>
 #include <sstream>
 
 namespace Bloomberg {

--- a/libamqpprox/amqpprox_fixedwindowconnectionratelimiter.h
+++ b/libamqpprox/amqpprox_fixedwindowconnectionratelimiter.h
@@ -20,7 +20,6 @@
 
 #include <chrono>
 #include <memory>
-#include <mutex>
 #include <string>
 
 namespace Bloomberg {
@@ -47,8 +46,8 @@ struct LimiterClock {
  * provided connection limit and time window. The connection rate limit will be
  * connection limit/timeWindow (average allowed connections in the specified
  * time window). allowNewConnection member function will return true or false
- * based on the rate limit calculation. Implements the LimiterInterface
- * interface
+ * based on the rate limit calculation. Implements the
+ * ConnectionLimiterInterface interface
  */
 class FixedWindowConnectionRateLimiter : public ConnectionLimiterInterface {
   protected:
@@ -97,7 +96,7 @@ class FixedWindowConnectionRateLimiter : public ConnectionLimiterInterface {
 
     // ACCESSORS
     /**
-     * \return Information about limiter as a string
+     * \return Information about connection limiter as a string
      */
     virtual std::string toString() const override;
 

--- a/libamqpprox/amqpprox_limitcontrolcommand.cpp
+++ b/libamqpprox/amqpprox_limitcontrolcommand.cpp
@@ -67,6 +67,7 @@ void handleConnectionLimitAlarm(
             output << "Default connection rate limit is set to "
                    << connectionLimiterManager
                           ->getAlarmOnlyDefaultConnectionRateLimit()
+                          .value()
                    << " connections per second in alarm only mode.\n";
             output << "The limiter will only log at warning level with "
                       "AMQPPROX_CONNECTION_LIMIT as a substring and the "
@@ -122,6 +123,7 @@ void handleConnectionLimit(
                 numberOfConnections);
             output << "Default connection rate limit is set to "
                    << connectionLimiterManager->getDefaultConnectionRateLimit()
+                          .value()
                    << " connections per second.\n";
         }
         else {
@@ -155,19 +157,19 @@ void printVhostLimits(
     }
 
     if (!alarmLimiter && !limiter) {
-        uint32_t alarmOnlyConnectionRateLimit =
+        std::optional<uint32_t> alarmOnlyConnectionRateLimit =
             connectionLimiterManager->getAlarmOnlyDefaultConnectionRateLimit();
-        uint32_t connectionRateLimit =
+        std::optional<uint32_t> connectionRateLimit =
             connectionLimiterManager->getDefaultConnectionRateLimit();
         if (alarmOnlyConnectionRateLimit || connectionRateLimit) {
             if (alarmOnlyConnectionRateLimit) {
                 output << "Alarm only limit, for vhost " << vhostName
-                       << ", allow average " << alarmOnlyConnectionRateLimit
+                       << ", allow average " << *alarmOnlyConnectionRateLimit
                        << " number of connections per second.\n";
             }
             if (connectionRateLimit) {
                 output << "For vhost " << vhostName << ", allow average "
-                       << connectionRateLimit
+                       << *connectionRateLimit
                        << " number of connections per second.\n";
             }
         }
@@ -182,19 +184,19 @@ void printAllLimits(
     ConnectionLimiterManager *connectionLimiterManager,
     ControlCommandOutput<ControlCommand::OutputFunctor> &output)
 {
-    uint32_t alarmOnlyConnectionRateLimit =
+    std::optional<uint32_t> alarmOnlyConnectionRateLimit =
         connectionLimiterManager->getAlarmOnlyDefaultConnectionRateLimit();
-    uint32_t connectionRateLimit =
+    std::optional<uint32_t> connectionRateLimit =
         connectionLimiterManager->getDefaultConnectionRateLimit();
     if (alarmOnlyConnectionRateLimit || connectionRateLimit) {
         if (alarmOnlyConnectionRateLimit) {
             output << "Default limit for any vhost, allow average "
-                   << alarmOnlyConnectionRateLimit
+                   << *alarmOnlyConnectionRateLimit
                    << " connections per second in alarm only mode.\n";
         }
         if (connectionRateLimit) {
             output << "Default limit for any vhost, allow average "
-                   << connectionRateLimit << " connections per second.\n";
+                   << *connectionRateLimit << " connections per second.\n";
         }
     }
     else {

--- a/tests/amqpprox_connectionlimitermanager.t.cpp
+++ b/tests/amqpprox_connectionlimitermanager.t.cpp
@@ -31,8 +31,8 @@ using namespace testing;
 TEST(ConnectionLimiterManagerTest, Breathing)
 {
     ConnectionLimiterManager limiterManager;
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(), 0);
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.getAlarmOnlyConnectionRateLimiter(
                     "test-vhost") == nullptr);
     EXPECT_TRUE(limiterManager.getConnectionRateLimiter("test-vhost") ==
@@ -165,48 +165,52 @@ TEST(ConnectionLimiterManagerTest, AddGetRemoveAlarmOnlyConnectionRateLimiter)
 TEST(ConnectionLimiterManagerTest, SetGetRemoveDefaultConnectionRateLimiter)
 {
     ConnectionLimiterManager limiterManager;
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(), 0);
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
 
     uint32_t connectionLimit1 = 100;
     // Setting default limiter
     limiterManager.setDefaultConnectionRateLimit(connectionLimit1);
 
     // Getting default limiter
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(),
+    ASSERT_TRUE(limiterManager.getDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getDefaultConnectionRateLimit(),
               connectionLimit1);
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
 
     uint32_t connectionLimit2 = 200;
     // Setting alarm only default limiter
     limiterManager.setAlarmOnlyDefaultConnectionRateLimit(connectionLimit2);
 
     // Getting alarm only default limiter
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(),
+    ASSERT_TRUE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getAlarmOnlyDefaultConnectionRateLimit(),
               connectionLimit2);
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(),
+    ASSERT_TRUE(limiterManager.getDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getDefaultConnectionRateLimit(),
               connectionLimit1);
 
     // Removing default limiter
     limiterManager.removeDefaultConnectionRateLimit();
 
     // Getting default limiter
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(),
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
+    ASSERT_TRUE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getAlarmOnlyDefaultConnectionRateLimit(),
               connectionLimit2);
 
     // Removing alarm only default limiter
     limiterManager.removeAlarmOnlyDefaultConnectionRateLimit();
 
     // Getting default limiter
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
+    EXPECT_FALSE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
 }
 
 TEST(ConnectionLimiterManagerTest, AllowNewConnectionForVhostWithoutAnyLimit)
 {
     ConnectionLimiterManager limiterManager;
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost("test-vhost"));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost("test-vhost"));
 }
@@ -216,13 +220,13 @@ TEST(ConnectionLimiterManagerTest,
 {
     ConnectionLimiterManager limiterManager;
     std::string              vhostName = "test-vhost";
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
 
     uint32_t connectionLimit = 1;
     limiterManager.addConnectionRateLimiter(vhostName, connectionLimit);
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_FALSE(limiterManager.allowNewConnectionForVhost(vhostName));
 }
@@ -232,14 +236,14 @@ TEST(ConnectionLimiterManagerTest,
 {
     ConnectionLimiterManager limiterManager;
     std::string              vhostName = "test-vhost";
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
 
     uint32_t connectionLimit = 1;
     limiterManager.addAlarmOnlyConnectionRateLimiter(vhostName,
                                                      connectionLimit);
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
 }
@@ -249,13 +253,15 @@ TEST(ConnectionLimiterManagerTest,
 {
     ConnectionLimiterManager limiterManager;
     std::string              vhostName = "test-vhost";
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
 
     uint32_t connectionLimit = 1;
     limiterManager.setDefaultConnectionRateLimit(connectionLimit);
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), connectionLimit);
+    ASSERT_TRUE(limiterManager.getDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getDefaultConnectionRateLimit(),
+              connectionLimit);
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_FALSE(limiterManager.allowNewConnectionForVhost(vhostName));
 }
@@ -265,13 +271,14 @@ TEST(ConnectionLimiterManagerTest,
 {
     ConnectionLimiterManager limiterManager;
     std::string              vhostName = "test-vhost";
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
 
     uint32_t connectionLimit = 1;
     limiterManager.setAlarmOnlyDefaultConnectionRateLimit(connectionLimit);
-    EXPECT_EQ(limiterManager.getAlarmOnlyDefaultConnectionRateLimit(),
+    ASSERT_TRUE(limiterManager.getAlarmOnlyDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getAlarmOnlyDefaultConnectionRateLimit(),
               connectionLimit);
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
@@ -283,24 +290,30 @@ TEST(ConnectionLimiterManagerTest,
     using namespace std::chrono_literals;
     ConnectionLimiterManager limiterManager;
     std::string              vhostName = "test-vhost";
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), 0);
+    EXPECT_FALSE(limiterManager.getDefaultConnectionRateLimit());
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
 
     uint32_t connectionLimit = 1;
     limiterManager.setDefaultConnectionRateLimit(connectionLimit);
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), connectionLimit);
+    ASSERT_TRUE(limiterManager.getDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getDefaultConnectionRateLimit(),
+              connectionLimit);
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_FALSE(limiterManager.allowNewConnectionForVhost(vhostName));
 
     uint32_t newConnectionLimit = 2;
     limiterManager.addConnectionRateLimiter(vhostName, newConnectionLimit);
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), connectionLimit);
+    ASSERT_TRUE(limiterManager.getDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getDefaultConnectionRateLimit(),
+              connectionLimit);
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
 
     limiterManager.removeConnectionRateLimiter(vhostName);
-    EXPECT_EQ(limiterManager.getDefaultConnectionRateLimit(), connectionLimit);
+    ASSERT_TRUE(limiterManager.getDefaultConnectionRateLimit());
+    EXPECT_EQ(*limiterManager.getDefaultConnectionRateLimit(),
+              connectionLimit);
     EXPECT_TRUE(limiterManager.allowNewConnectionForVhost(vhostName));
     EXPECT_FALSE(limiterManager.allowNewConnectionForVhost(vhostName));
 }


### PR DESCRIPTION
We are allowing to configure zero connection rate limit using `amqpprox_ctl` LIMIT command. But in that case, `connectionLimiterManager` will consider zero value as no limiter. So the PR fixes that issue. Now, the default limits will be maintained as `std::optional`. So boolean value can differentiate between zero and no value.
