### PR TITLE
Add Data Transfer Limits for each connection, configurable by vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ EXIT Exit the program gracefully.
 FARM (ADD name selector backend* | PARTITION name policy | DELETE name | PRINT) - Change farms
 HELP Print this help text.
 LIMIT (CONN_RATE_ALARM | CONN_RATE) (VHOST vhostName numberOfConnections | DEFAULT numberOfConnections) - Configure connection rate limits (normal or alarmonly) for incoming clients connections
-LIMIT DISABLE (CONN_RATE_ALARM | CONN_RATE) (VHOST vhostName | DEFAULT) - Disable configured connection rate limits (normal or alarmonly) for incoming clients
+LIMIT (DATA_RATE_ALARM | DATA_RATE) (DEFAULT | VHOST vhostName) BytesPerSecond - Configure data rate limits or alarms for incoming client data
+LIMIT DISABLE (CONN_RATE_ALARM | CONN_RATE | DATA_RATE_ALARM | DATA_RATE) (VHOST vhostName | DEFAULT) - Disable configured limit thresholds
 LIMIT PRINT [vhostName] - Print the configured default or specific connection rate limits for specified vhost
 LISTEN START port | START_SECURE port | STOP [port]
 LOG CONSOLE verbosity | FILE verbosity

--- a/libamqpprox/CMakeLists.txt
+++ b/libamqpprox/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(libamqpprox STATIC
     amqpprox_cpumonitor.cpp
     amqpprox_datacenter.cpp
     amqpprox_datacentercontrolcommand.cpp
+    amqpprox_dataratelimit.cpp
+    amqpprox_dataratelimitmanager.cpp
     amqpprox_dnshostnamemapper.cpp
     amqpprox_dnsresolver.cpp
     amqpprox_eventsource.cpp

--- a/libamqpprox/amqpprox_dataratelimit.cpp
+++ b/libamqpprox/amqpprox_dataratelimit.cpp
@@ -1,0 +1,74 @@
+/*
+** Copyright 2022 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_dataratelimit.h>
+
+#include <algorithm>
+#include <limits>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+DataRateLimit::DataRateLimit()
+: d_quota(std::numeric_limits<std::size_t>::max())
+, d_remainingQuota(d_quota)
+{
+}
+
+DataRateLimit::DataRateLimit(DataRateLimit &src)
+: d_quota(src.d_quota.load())
+, d_remainingQuota(src.d_remainingQuota)
+{
+}
+
+void DataRateLimit::setQuota(std::size_t bytesPerSecond)
+{
+    d_quota = bytesPerSecond;
+}
+
+std::size_t DataRateLimit::getQuota() const
+{
+    return d_quota;
+}
+
+void DataRateLimit::recordUsage(std::size_t bytesRead)
+{
+    if (d_quota == std::numeric_limits<std::size_t>::max()) {
+        // We don't trigger quota limits for this d_quota value
+        return;
+    }
+
+    if (d_quota < d_remainingQuota) {
+        // Apply the updated, restricted quota without needing to synchronise
+        // setQuota and recordUsage
+        d_remainingQuota = d_quota;
+    }
+
+    d_remainingQuota -= std::min(d_remainingQuota, bytesRead);
+}
+
+std::size_t DataRateLimit::remainingQuota() const
+{
+    return d_remainingQuota;
+}
+
+void DataRateLimit::onTimer()
+{
+    d_remainingQuota = d_quota;
+}
+
+}
+}

--- a/libamqpprox/amqpprox_dataratelimit.h
+++ b/libamqpprox/amqpprox_dataratelimit.h
@@ -1,0 +1,71 @@
+/*
+** Copyright 2022 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef BLOOMBERG_AMQPPROX_DATARATELIMIT
+#define BLOOMBERG_AMQPPROX_DATARATELIMIT
+
+#include <atomic>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+/**
+ * \brief Measures and reports usage with the aim to limit usage.
+ *
+ * \note Thread Safety - Calls to onTimer, recordUsage, and remainingQuota must
+ * occur serially.
+ *
+ * \note Thread Safety - setQuota is safe from any thread
+ */
+class DataRateLimit {
+  public:
+    DataRateLimit();
+    DataRateLimit(DataRateLimit &src);
+
+    /**
+     * Set the total permitted usage in bytes per second
+     * \note std::numeric_limits<size_t>::max counts as infinite quota
+     */
+    void setQuota(std::size_t bytesPerSecond);
+
+    /**
+     * Fetch the currently configured quota
+     */
+    std::size_t getQuota() const;
+
+    /**
+     * Record some usage, which will affect the return of `remainingQuota`
+     */
+    void recordUsage(std::size_t bytesRead);
+
+    /**
+     * Query how much quota is left in the current time period
+     */
+    std::size_t remainingQuota() const;
+
+    /**
+     * Reset the current usage by incrementing the time period
+     */
+    void onTimer();
+
+  private:
+    std::atomic<std::size_t> d_quota;
+    std::size_t              d_remainingQuota;
+};
+
+}
+}
+
+#endif

--- a/libamqpprox/amqpprox_dataratelimitmanager.cpp
+++ b/libamqpprox/amqpprox_dataratelimitmanager.cpp
@@ -1,0 +1,121 @@
+/*
+** Copyright 2022 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_dataratelimitmanager.h>
+
+#include <limits>
+#include <string>
+#include <mutex>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+DataRateLimitManager::DataRateLimitManager()
+: d_vhostDataRateQuota()
+, d_vhostDataRateAlarmQuota()
+, d_defaultDataRateQuota(std::numeric_limits<std::size_t>::max())
+, d_defaultDataRateAlarmQuota(std::numeric_limits<std::size_t>::max())
+, d_mutex()
+{
+}
+
+std::size_t
+DataRateLimitManager::getDataRateLimit(const std::string &vhostName) const
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    auto vhostRate = d_vhostDataRateQuota.find(vhostName);
+    if (vhostRate == d_vhostDataRateQuota.end()) {
+        return d_defaultDataRateQuota;
+    }
+
+    return vhostRate->second;
+}
+
+std::size_t
+DataRateLimitManager::getDataRateAlarm(const std::string &vhostName) const
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    auto vhostRate = d_vhostDataRateAlarmQuota.find(vhostName);
+    if (vhostRate == d_vhostDataRateAlarmQuota.end()) {
+        return d_defaultDataRateAlarmQuota;
+    }
+
+    return vhostRate->second;
+}
+
+std::size_t DataRateLimitManager::getDefaultDataRateLimit() const
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    return d_defaultDataRateQuota;
+}
+
+std::size_t DataRateLimitManager::getDefaultDataRateAlarm() const
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    return d_defaultDataRateAlarmQuota;
+}
+
+void DataRateLimitManager::setDefaultDataRateLimit(std::size_t quota)
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    d_defaultDataRateQuota = quota;
+}
+
+void DataRateLimitManager::setDefaultDataRateAlarm(std::size_t quota)
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    d_defaultDataRateAlarmQuota = quota;
+}
+
+void DataRateLimitManager::setVhostDataRateLimit(const std::string &vhostName,
+                                                 std::size_t        quota)
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    d_vhostDataRateQuota[vhostName] = quota;
+}
+
+void DataRateLimitManager::setVhostDataRateAlarm(const std::string &vhostName,
+                                                 std::size_t        quota)
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    d_vhostDataRateAlarmQuota[vhostName] = quota;
+}
+
+void DataRateLimitManager::disableVhostDataRateLimit(
+    const std::string &vhostName)
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    d_vhostDataRateQuota.erase(vhostName);
+}
+void DataRateLimitManager::disableVhostDataRateAlarm(
+    const std::string &vhostName)
+{
+    std::lock_guard<std::mutex> lg(d_mutex);
+
+    d_vhostDataRateAlarmQuota.erase(vhostName);
+}
+
+}
+}

--- a/libamqpprox/amqpprox_dataratelimitmanager.h
+++ b/libamqpprox/amqpprox_dataratelimitmanager.h
@@ -1,0 +1,92 @@
+/*
+** Copyright 2022 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+#ifndef BLOOMBERG_AMQPPROX_DATARATELIMITMANAGER
+#define BLOOMBERG_AMQPPROX_DATARATELIMITMANAGER
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace Bloomberg {
+namespace amqpprox {
+
+class DataRateLimitManager {
+    std::unordered_map<std::string, std::size_t> d_vhostDataRateQuota;
+    std::unordered_map<std::string, std::size_t> d_vhostDataRateAlarmQuota;
+    std::size_t                                  d_defaultDataRateQuota;
+    std::size_t                                  d_defaultDataRateAlarmQuota;
+    mutable std::mutex                           d_mutex;
+
+  public:
+    DataRateLimitManager();
+
+    /**
+     * Get the rate limit for a particular vhost
+     */
+    std::size_t getDataRateLimit(const std::string &vhostName) const;
+
+    /**
+     * Get the rate alarm threshold for a particular vhost
+     */
+    std::size_t getDataRateAlarm(const std::string &vhostName) const;
+
+    /**
+     * Get the non-vhost-specific rate limit
+     */
+    std::size_t getDefaultDataRateLimit() const;
+
+    /**
+     * Get the non-vhost-specific alarm threshold
+     */
+    std::size_t getDefaultDataRateAlarm() const;
+
+    /**
+     * Set the non-vhost-specific rate limit
+     */
+    void setDefaultDataRateLimit(std::size_t quota);
+
+    /**
+     * Set the non-vhost-specific alarm threshold
+     */
+    void setDefaultDataRateAlarm(std::size_t quota);
+
+    /**
+     * Set the rate limit for a particular vhost
+     */
+    void setVhostDataRateLimit(const std::string &vhostName,
+                               std::size_t        quota);
+
+    /**
+     * Set the rate alarm threshold for a particular vhost
+     */
+    void setVhostDataRateAlarm(const std::string &vhostName,
+                               std::size_t        quota);
+
+    /**
+     * Disable the vhost specific rate limit
+     */
+    void disableVhostDataRateLimit(const std::string &vhostName);
+
+    /**
+     * Disable the vhost specific rate alarm threshold
+     */
+    void disableVhostDataRateAlarm(const std::string &vhostName);
+};
+
+}
+}
+
+#endif

--- a/libamqpprox/amqpprox_limitcontrolcommand.h
+++ b/libamqpprox/amqpprox_limitcontrolcommand.h
@@ -29,11 +29,13 @@ class ConnectionLimiterManager;
 
 class LimitControlCommand : public ControlCommand {
     ConnectionLimiterManager *d_connectionLimiterManager_p;  // HELD NOT OWNED
+    DataRateLimitManager     *d_dataRateLimitManager;        // HELD NOT OWNED
 
   public:
     // CREATORS
     explicit LimitControlCommand(
-        ConnectionLimiterManager *connectionLimiterManager);
+        ConnectionLimiterManager *connectionLimiterManager,
+        DataRateLimitManager     *dataRateLimitManager);
 
     virtual ~LimitControlCommand() override = default;
 

--- a/libamqpprox/amqpprox_server.cpp
+++ b/libamqpprox/amqpprox_server.cpp
@@ -61,7 +61,8 @@ void initTLS(boost::asio::ssl::context &context)
 
 Server::Server(ConnectionSelectorInterface *selector,
                EventSource                 *eventSource,
-               BufferPool                  *bufferPool)
+               BufferPool                  *bufferPool,
+               DataRateLimitManager        *limitManager)
 : d_ioContext()
 , d_ingressTlsContext(boost::asio::ssl::context::tlsv12)
 , d_egressTlsContext(boost::asio::ssl::context::tlsv12)
@@ -77,6 +78,7 @@ Server::Server(ConnectionSelectorInterface *selector,
 , d_hostnameMapper()
 , d_localHostname(boost::asio::ip::host_name())
 , d_authIntercept(std::make_shared<DefaultAuthIntercept>(d_ioContext))
+, d_limitManager(limitManager)
 {
     d_dnsResolver.setCacheTimeout(1000);
     d_dnsResolver.startCleanupTimer();
@@ -219,7 +221,8 @@ void Server::doAccept(int port, bool secure)
                                               d_hostnameMapper,
                                               d_localHostname,
                                               d_authIntercept,
-                                              secure);
+                                              secure,
+                                              d_limitManager);
 
                 {
                     std::lock_guard<std::mutex> lg(d_mutex);

--- a/libamqpprox/amqpprox_server.h
+++ b/libamqpprox/amqpprox_server.h
@@ -36,6 +36,7 @@ class BufferPool;
 class Session;
 class EventSource;
 class HostnameMapper;
+class DataRateLimitManager;
 
 /**
  * \brief Sockets are accept()'ed in this component. For each incoming
@@ -60,11 +61,13 @@ class Server {
     std::shared_ptr<HostnameMapper> d_hostnameMapper;
     std::string                     d_localHostname;
     std::shared_ptr<AuthInterceptInterface> d_authIntercept;
+    DataRateLimitManager                   *d_limitManager;  // HELD NOT OWNED
 
   public:
     Server(ConnectionSelectorInterface *selector,
            EventSource                 *eventSource,
-           BufferPool                  *bufferPool);
+           BufferPool                  *bufferPool,
+           DataRateLimitManager        *limitManager);
 
     ~Server();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(amqpprox_tests
     amqpprox_bufferpool.t.cpp
     amqpprox_buffersource.t.cpp
     amqpprox_connectionstats.t.cpp
+    amqpprox_dataratelimit.t.cpp
     amqpprox_dnsresolver.t.cpp
     amqpprox_eventsourcesignal.t.cpp
     amqpprox_farmstore.t.cpp

--- a/tests/amqpprox_dataratelimit.t.cpp
+++ b/tests/amqpprox_dataratelimit.t.cpp
@@ -1,0 +1,92 @@
+/*
+** Copyright 2022 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_dataratelimit.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+using Bloomberg::amqpprox::DataRateLimit;
+
+TEST(DataRateLimit, DefaultLimit)
+{
+    DataRateLimit rate;
+
+    EXPECT_THAT(rate.remainingQuota(), Eq(std::numeric_limits<size_t>::max()));
+}
+
+TEST(DataRateLimit, QuotaChangesOnTimerForUpdate)
+{
+    DataRateLimit rate;
+    EXPECT_THAT(rate.getQuota(), Eq(std::numeric_limits<size_t>::max()));
+
+    rate.setQuota(500);
+    EXPECT_THAT(rate.getQuota(), Eq(500));
+
+    // remainingQuota only updates during recordUsage or onTimer.
+    // Still the old value
+    EXPECT_THAT(rate.remainingQuota(), Eq(std::numeric_limits<size_t>::max()));
+
+    rate.onTimer();
+
+    EXPECT_THAT(rate.remainingQuota(), Eq(500));
+}
+
+TEST(DataRateLimit, QuotaChangesRecordUsageForUpdate)
+{
+    DataRateLimit rate;
+    EXPECT_THAT(rate.getQuota(), Eq(std::numeric_limits<size_t>::max()));
+
+    rate.setQuota(500);
+    EXPECT_THAT(rate.getQuota(), Eq(500));
+
+    // remainingQuota only updates during recordUsage or onTimer.
+    // Still the old value
+    EXPECT_THAT(rate.remainingQuota(), Eq(std::numeric_limits<size_t>::max()));
+
+    rate.recordUsage(0);
+
+    EXPECT_THAT(rate.remainingQuota(), Eq(500));
+}
+
+TEST(DataRateLimit, Consumption)
+{
+    DataRateLimit rate;
+
+    rate.setQuota(500);
+
+    rate.recordUsage(50);
+
+    EXPECT_THAT(rate.getQuota(), Eq(500));
+
+    EXPECT_THAT(rate.remainingQuota(), Eq(450));
+}
+
+TEST(DataRateLimit, ConsumptionAndReset)
+{
+    DataRateLimit rate;
+
+    rate.setQuota(500);
+    rate.recordUsage(50);
+
+    EXPECT_THAT(rate.remainingQuota(), Eq(450));
+
+    rate.onTimer();
+
+    EXPECT_THAT(rate.remainingQuota(), Eq(500));
+}

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -45,6 +45,7 @@
 #include <amqpprox_connectionselectorinterface.h>
 #include <amqpprox_connectorutil.h>
 #include <amqpprox_constants.h>
+#include <amqpprox_dataratelimitmanager.h>
 #include <amqpprox_defaultauthintercept.h>
 #include <amqpprox_dnsresolver.h>
 #include <amqpprox_eventsource.h>
@@ -150,6 +151,7 @@ class SessionTest : public ::testing::Test {
     int                                         d_step;
     std::shared_ptr<AuthInterceptInterface>     d_authIntercept;
     std::shared_ptr<AuthInterceptInterfaceMock> d_mockAuthIntercept;
+    DataRateLimitManager                        d_limitManager;
 
     SessionTest();
 
@@ -238,7 +240,8 @@ SessionTest::makeSession(MaybeSecureSocketAdaptor              &&clientSocket,
                                      d_mapper,
                                      LOCAL_HOSTNAME,
                                      authIntercept,
-                                     false);
+                                     false,
+                                     &d_limitManager);
 }
 
 template <typename TYPE>


### PR DESCRIPTION
This commit adds support for limiting the amount of data which can be
read from the client-side (ingress) socket in a one second time period.

The aim is to be able to avoid one single connection being able to
overwhelm the proxy, while also providing an extra tool for limiting an
out of control vhost - giving time for both RabbitMQ, and amqpprox to
recover.

These limits are configurable using
```
amqpprox_ctl ... LIMIT DATA_RATE DEFAULT 500000000 # About 500MB per second limit per connection on all vhosts

amqpprox_ctl ... LIMIT DATA_RATE VHOST vhostname 5000000 # Restrict 'vhostname' down to about 5MB/s
```

The limits are enforced by counting the number of bytes read from the
socket during each read operation, and pausing for one second before
starting a read operation if the connection is at the limit.

This might transfer a bit more data than the precise limit since amqpprox
will always pass the whole read buffer to the server after a read operation - which
technically could lead to overshooting the limit, but the next read operation will pause for
until the next 'tick' (up to one second) after doing so. In testing the data transferred per second
stays roughly at the configured limit such that this isn't a huge problem.

I tested and compared maximum data throughput before and after this
change - with no limit enabled and with a high limit enabled. No
particular differences were seen:
Data Transfer rates all measured in / MiB/s

| Run # | Without Change             | With Change<br/>No Limit | With Change<br/>2000MiB/s Limit | With Change<br/>50MiB/s Limit (per client)  | 
|---|---------------------|-------------------------------|--------------|----------------------|
| 1 | 1058                       | 1078                                    | 1064            | 497                        |  
| 2 | 1056                       | 1030                                    | 1060            | 497                        |  
| 3 | 1049                       | 1023                                    | 1054            | 497                        | 

Tested with amqpprox and the performance tester running on the same machine - a VM with 8x 2.5GHz cores and 32GB of ram

I ran the performance tester using these arguments:

```
$ RUST_LOG=info cargo run --release -- --address amqp://127.0.0.1:5672 --listen-address 0.0.0.0:30424 --message-size 10000000 --num-messages 500 --clients 10 --max-threads 50 
```
This runs 10 parallel client threads transmitting ~5000GB each as fast as they can. Each test run took between ~45seconds and ~2-3minutes, depending on whether the rate limit was applied. Longer tests better reflect the true peak data rate achieved since some setup/teardown time is included in the summary calculations. Using `bmon` I could see that most of the tests were peaking at around 2.2-2.4GiB/s which means our results here aren't too far off that - since the number in bmon reflects the `client -> proxy -> server` data flow all over the same interface.

When amqpprox has a large number of connections which have hit their
limit at least once since being opened (this triggers the one second
reset interval) there is some additional CPU load from this change.

I run the following experiment:

1. Start amqpprox
2. Connect 21k clients which send a 100byte message every minute
3. Measure CPU usage of amqpprox using `pidstat 15 5 -ru -p <pid>`

In a few different scenarios:
1. `amqpprox` without this change
2. With the change, with no data rate limits configured
3. With the change, with a low data rate limit configured (50 bytes per second)
4. With the change, with a high data rate limit configured but with all timers triggering.
    -  Triggering all timers was possible by setting the data rate limit very low (50b/s) for a couple of minutes, then set it high: 2GB/s.
    
Results:

| Cpu usage tests | Without Change | No Limit | Low limit | All connections triggering timers |
|-----------------|----------------|----------|-----------|-----------------------------------|
| %CPU sample 1   |          17.93 |     13.4 |     19.53 |                              20.8 |
| %CPU sample 2   |          15.73 |     18.4 |     12.73 |                             24.27 |
| %CPU sample 3   |           18.8 |    14.53 |      18.8 |                             21.47 |
| %CPU sample 4   |          17.73 |    18.07 |     13.33 |                             23.87 |
| %CPU sample 5   |          18.73 |     13.4 |     19.47 |                             20.67 |
| %CPU average    |          17.79 |    15.56 |     16.77 |                             22.21 |

I started amqpprox, setup 21k clients connecting to it which publish a 100byte message every minute.

TODO:
 - [x] Re-run cpu usage comparisons with 20k connections and put the results on this PR
 - [x] Figure out the clang-format changes going on here - unsure why it's reformatting some code which looks fine.