### PR TITLE
Add a new STAT ENABLE/DISABLE feature to skip collecting per-source data

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ MAP (BACKEND vhost backend | FARM vhost name | UNMAP vhost | DEFAULT farmName | 
 MAPHOSTNAME DNS - Set up mapping of IPs to hostnames
 SESSION  id# (PAUSE|DISCONNECT_GRACEFUL|FORCE_DISCONNECT) - Control a particular session
 STAT (STOP SEND | SEND <host> <port> | (LISTEN (json|human) (overall|vhost=foo|backend=bar|source=baz|all|process|bufferpool))) - Output statistics
+STAT (DISABLE|ENABLE) per-source - Enable/Disable internal collection of per-source statistics. Applies to all send/listeners
 TLS (INGRESS | EGRESS) (KEY_FILE file | CERT_CHAIN_FILE file | RSA_KEY_FILE file | TMP_DH_FILE file | CA_CERT_FILE file | VERIFY_MODE mode* | CIPHERS (PRINT | SET ciphersuite(:ciphersuite)*))
 VHOST PAUSE vhost | UNPAUSE vhost | PRINT | BACKEND_DISCONNECT vhost | FORCE_DISCONNECT vhost
 ```

--- a/amqpprox/amqpprox.m.cpp
+++ b/amqpprox/amqpprox.m.cpp
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
         CommandPtr(new VhostControlCommand(&vhostState)),
         CommandPtr(new ListenControlCommand),
         CommandPtr(new LoggingControlCommand),
-        CommandPtr(new StatControlCommand(&eventSource)),
+        CommandPtr(new StatControlCommand(&eventSource, &statCollector)),
         CommandPtr(new MapHostnameControlCommand()),
         CommandPtr(new TlsControlCommand),
         CommandPtr(new AuthControlCommand),

--- a/docs/config.md
+++ b/docs/config.md
@@ -248,6 +248,13 @@ Stops sending metrics to all configured endpoints.
 
 Streams metrics to stdout. Pass `json` or `human` to specify output format. Metrics can be filtered by passing `overall|vhost=foo|backend=bar|source=baz|all|process|bufferpool`.
 
+#### STAT ENABLE/DISABLE
+
+Disable internal collection of certain types of metrics. This is different from the filtering available under `STAT LISTEN` because this completely skips collection
+of these metrics. Where possible, use this instead of filters.
+
+At the moment, only `STAT DISABLE per-source` (or enable equivalent) is available.
+
 ## TLS commands
 
 `TLS` command is used to configure TLS-enabled connections for both ingress (client => proxy) and egress (proxy => broker). See [TLS usage documentation](https://github.com/bloomberg/amqpprox/blob/main/docs/tls.md).

--- a/libamqpprox/amqpprox_statcollector.h
+++ b/libamqpprox/amqpprox_statcollector.h
@@ -19,6 +19,7 @@
 #include <amqpprox_connectionstats.h>
 #include <amqpprox_statsnapshot.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -52,6 +53,8 @@ class StatCollector {
     StatSnapshot d_previous;
     CpuMonitor  *d_cpuMonitor_p;  // HELD NOT OWNED
     BufferPool  *d_bufferPool_p;  // HELD NOT OWNED
+
+    std::atomic<bool> d_collectPerSourceStats;
 
   public:
     // CREATORS
@@ -89,6 +92,11 @@ class StatCollector {
      * \param pool pointer to `BuffrePool`
      */
     void setBufferPool(BufferPool *pool);
+
+    /**
+     * \brief Enable/Disable per-source statistics
+     */
+    void collectPerSourceStats(bool enabled);
 
     // ACCESSORS
     /**

--- a/libamqpprox/amqpprox_statcontrolcommand.h
+++ b/libamqpprox/amqpprox_statcontrolcommand.h
@@ -40,9 +40,11 @@ class StatControlCommand : public ControlCommand {
     std::list<std::pair<StatFunctor, bool>> d_functors;
     EventSubscriptionHandle                 d_statisticsAvailableSignal;
     EventSource                            *d_eventSource_p;  // HELD NOT OWNED
+    StatCollector *d_statCollector_p;                         // HELD NOT OWNED
 
   public:
-    explicit StatControlCommand(EventSource *eventSource);
+    explicit StatControlCommand(EventSource   *eventSource,
+                                StatCollector *statCollector);
 
     /**
      * \return the command verb this handles


### PR DESCRIPTION
From looking at perf data, and also our internal timeseries usage, per-source metric data
is expensive to collect, store, and we rarely look at it.

Sometimes it might be useful to collect this, for example when there are few distinct sources,
but I suspect we'll disable these nearly all the time going forward.

This is slightly different from the existing filter feature because
enabling/disabling these applies to all stats output functions. The
filters also don't actually change what is internally collected - i.e.
the work for per-source metrics still shows up in perf with a filter
applied

Disabling these stats make a slight different to `perf report` - a 30 second sample of amqpprox with 5000 connections shows
`Bloomberg::amqpprox::StatCollector::collect` taking ~8% of samples instead of 10%. Several string allocation/free functions also drop further down the perf report.