### PR TITLE
Start unit testing MaybeSecureSocketAdaptor

### DIFF
--- a/libamqpprox/amqpprox_server.cpp
+++ b/libamqpprox/amqpprox_server.cpp
@@ -199,15 +199,15 @@ void Server::doAccept(int port, bool secure)
         return;
     }
 
-    std::shared_ptr<MaybeSecureSocketAdaptor> incomingSocket =
-        std::make_shared<MaybeSecureSocketAdaptor>(
+    std::shared_ptr<MaybeSecureSocketAdaptor<>> incomingSocket =
+        std::make_shared<MaybeSecureSocketAdaptor<>>(
             d_ioContext, d_ingressTlsContext, secure);
 
     it->second.async_accept(
         incomingSocket->socket(),
         [this, port, secure, incomingSocket](error_code ec) {
             if (!ec) {
-                MaybeSecureSocketAdaptor clientSocket(
+                MaybeSecureSocketAdaptor<> clientSocket(
                     d_ioContext, d_egressTlsContext, false);
 
                 auto session =

--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -112,8 +112,8 @@ void logException(const std::string_view error,
 }
 
 Session::Session(boost::asio::io_context               &ioContext,
-                 MaybeSecureSocketAdaptor             &&serverSocket,
-                 MaybeSecureSocketAdaptor             &&clientSocket,
+                 MaybeSecureSocketAdaptor<>           &&serverSocket,
+                 MaybeSecureSocketAdaptor<>           &&clientSocket,
                  ConnectionSelectorInterface           *connectionSelector,
                  EventSource                           *eventSource,
                  BufferPool                            *bufferPool,
@@ -684,9 +684,9 @@ void Session::backendDisconnect()
     });
 }
 
-void Session::handleWriteData(FlowType                  direction,
-                              MaybeSecureSocketAdaptor &writeSocket,
-                              Buffer                    data)
+void Session::handleWriteData(FlowType                    direction,
+                              MaybeSecureSocketAdaptor<> &writeSocket,
+                              Buffer                      data)
 {
     auto self(shared_from_this());
     auto writeHandler = [this, self, direction](error_code ec, std::size_t) {

--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -61,8 +61,8 @@ class Session : public std::enable_shared_from_this<Session> {
         std::chrono::time_point<std::chrono::high_resolution_clock>;
 
     boost::asio::io_context     &d_ioContext;
-    MaybeSecureSocketAdaptor     d_serverSocket;
-    MaybeSecureSocketAdaptor     d_clientSocket;
+    MaybeSecureSocketAdaptor<>   d_serverSocket;
+    MaybeSecureSocketAdaptor<>   d_clientSocket;
     BufferHandle                 d_serverDataHandle;
     BufferHandle                 d_serverWriteDataHandle;
     BufferHandle                 d_clientDataHandle;
@@ -90,8 +90,8 @@ class Session : public std::enable_shared_from_this<Session> {
   public:
     // CREATORS
     Session(boost::asio::io_context                       &ioContext,
-            MaybeSecureSocketAdaptor                     &&serverSocket,
-            MaybeSecureSocketAdaptor                     &&clientSocket,
+            MaybeSecureSocketAdaptor<>                   &&serverSocket,
+            MaybeSecureSocketAdaptor<>                   &&clientSocket,
             ConnectionSelectorInterface                   *connectionSelector,
             EventSource                                   *eventSource,
             BufferPool                                    *bufferPool,
@@ -238,9 +238,9 @@ class Session : public std::enable_shared_from_this<Session> {
      * \param writeSocket to write the data
      * \param data to be written onto the outgoing socket
      */
-    void handleWriteData(FlowType                  direction,
-                         MaybeSecureSocketAdaptor &writeSocket,
-                         Buffer                    data);
+    void handleWriteData(FlowType                    direction,
+                         MaybeSecureSocketAdaptor<> &writeSocket,
+                         Buffer                      data);
 
     /**
      * \brief Handle errors on an established connection
@@ -280,7 +280,7 @@ class Session : public std::enable_shared_from_this<Session> {
      * \param direction specifies direction of the data flow (ingress/egress)
      * \return a mutable reference to the socket to read from
      */
-    inline MaybeSecureSocketAdaptor &readSocket(FlowType direction);
+    inline MaybeSecureSocketAdaptor<> &readSocket(FlowType direction);
 
     /**
      * \param direction specifies direction of the data flow (ingress/egress)
@@ -329,7 +329,7 @@ class Session : public std::enable_shared_from_this<Session> {
     inline bool &currentlyReading(FlowType direction);
 };
 
-inline MaybeSecureSocketAdaptor &Session::readSocket(FlowType direction)
+inline MaybeSecureSocketAdaptor<> &Session::readSocket(FlowType direction)
 {
     return (direction == FlowType::INGRESS) ? d_serverSocket : d_clientSocket;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,14 +18,19 @@ add_executable(amqpprox_tests
     amqpprox_bufferhandle.t.cpp
     amqpprox_bufferpool.t.cpp
     amqpprox_buffersource.t.cpp
+    amqpprox_connectionlimitermanager.t.cpp
+    amqpprox_connectionselector.t.cpp
     amqpprox_connectionstats.t.cpp
     amqpprox_dataratelimit.t.cpp
+    amqpprox_defaultauthintercept.t.cpp
     amqpprox_dnsresolver.t.cpp
     amqpprox_eventsourcesignal.t.cpp
     amqpprox_farmstore.t.cpp
-    amqpprox_frame.t.cpp
+    amqpprox_fixedwindowconnectionratelimiter.t.cpp
     amqpprox_flowtype.t.cpp
-    amqpprox_connectionselector.t.cpp
+    amqpprox_frame.t.cpp
+    amqpprox_httpauthintercept.t.cpp
+    amqpprox_maybesecuresocketadaptor.t.cpp
     amqpprox_methods_start.t.cpp
     amqpprox_packetprocessor.t.cpp
     amqpprox_partitionpolicystore.t.cpp
@@ -38,10 +43,6 @@ add_executable(amqpprox_tests
     amqpprox_statsnapshot.t.cpp
     amqpprox_types.t.cpp
     amqpprox_vhoststate.t.cpp
-    amqpprox_defaultauthintercept.t.cpp
-    amqpprox_httpauthintercept.t.cpp
-    amqpprox_fixedwindowconnectionratelimiter.t.cpp
-    amqpprox_connectionlimitermanager.t.cpp
     )
 
 target_include_directories(amqpprox_tests PRIVATE ${PROTO_HDR_PATH})

--- a/tests/amqpprox_maybesecuresocketadaptor.t.cpp
+++ b/tests/amqpprox_maybesecuresocketadaptor.t.cpp
@@ -1,0 +1,207 @@
+/*
+** Copyright 2022 Bloomberg Finance L.P.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <amqpprox_maybesecuresocketadaptor.h>
+
+#include <boost/asio/buffer.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+
+using namespace Bloomberg;
+using namespace amqpprox;
+
+using namespace ::testing;
+
+using DummyIoContext  = int;
+using DummyTlsContext = int;
+
+class SocketInterface {
+  public:
+    virtual void
+    async_read_some(boost::asio::null_buffers,
+                    std::function<void(const boost::system::error_code &error,
+                                       size_t numBytes)> handler) = 0;
+
+    virtual void
+    async_read_some(boost::asio::mutable_buffers_1,
+                    std::function<void(const boost::system::error_code &error,
+                                       size_t numBytes)> handler) = 0;
+
+    virtual size_t read_some(const boost::asio::mutable_buffers_1 &buffer,
+                             boost::system::error_code            &error) = 0;
+
+    virtual ~SocketInterface(){};
+};
+
+class MockSocket : public SocketInterface {
+  public:
+    static MockSocket *instance;
+    MockSocket(DummyIoContext &) { instance = this; };
+    MockSocket(DummyIoContext &, DummyTlsContext &) { instance = this; };
+    typedef int executor_type;
+
+    MOCK_METHOD2(
+        async_read_some,
+        void(boost::asio::null_buffers,
+             std::function<void(const boost::system::error_code &, size_t)>));
+
+    MOCK_METHOD2(
+        async_read_some,
+        void(boost::asio::mutable_buffers_1,
+             std::function<void(const boost::system::error_code &, size_t)>));
+
+    MOCK_METHOD2(read_some,
+                 size_t(const boost::asio::mutable_buffers_1 &,
+                        boost::system::error_code &));
+
+    MockSocket &next_layer() { return *this; }
+};
+
+class TimerInterface {
+  public:
+    virtual ~TimerInterface(){};
+    virtual void cancel() = 0;
+
+    virtual size_t
+    expires_at(const std::chrono::steady_clock::time_point &expiry_time) = 0;
+
+    virtual std::chrono::steady_clock::time_point expiry() = 0;
+
+    virtual size_t
+    expires_after(const std::chrono::steady_clock::duration &expiry_time) = 0;
+
+    virtual void
+    async_wait(std::function<void(const boost::system::error_code &error)>
+                   handler) = 0;
+};
+
+class MockTimer : public TimerInterface {
+  public:
+    static MockTimer *instance;
+    MockTimer(int &) { instance = this; };
+
+    MOCK_METHOD0(cancel, void());
+    MOCK_METHOD1(expires_at,
+                 size_t(const std::chrono::steady_clock::time_point &));
+    MOCK_METHOD0(expiry, std::chrono::steady_clock::time_point());
+    MOCK_METHOD1(expires_after,
+                 size_t(const std::chrono::steady_clock::duration &));
+    MOCK_METHOD1(
+        async_wait,
+        void(std::function<void(const boost::system::error_code &error)>));
+};
+
+MockTimer  *MockTimer::instance  = nullptr;
+MockSocket *MockSocket::instance = nullptr;
+
+TEST(MaybeSecureSocketAdaptor, alive)
+{
+    DummyIoContext  ioContext  = 5;
+    DummyTlsContext tlsContext = 5;
+
+    MaybeSecureSocketAdaptor<MockSocket,
+                             MockTimer,
+                             DummyIoContext,
+                             DummyTlsContext>
+        socket(ioContext, tlsContext, false);
+}
+
+TEST(MaybeSecureSocketAdaptorDataRateLimit, LimitEventuallyHit)
+{
+    DummyIoContext  ioContext  = 5;
+    DummyTlsContext tlsContext = 5;
+    MaybeSecureSocketAdaptor<MockSocket,
+                             MockTimer,
+                             DummyIoContext,
+                             DummyTlsContext>
+        socket(ioContext, tlsContext, false);
+
+    // This test requires a few timer methods. At this point we don't
+    // explicitly test these, but the fact they are called is still worth
+    // asserting
+    EXPECT_CALL(*MockTimer::instance, cancel()).WillRepeatedly(Return());
+    EXPECT_CALL(*MockTimer::instance, expires_at(_)).WillRepeatedly(Return(0));
+    EXPECT_CALL(*MockTimer::instance, expires_after(_))
+        .WillRepeatedly(Return(0));
+    EXPECT_CALL(*MockTimer::instance, expiry())
+        .WillRepeatedly(Return(std::chrono::steady_clock::time_point()));
+    EXPECT_CALL(*MockTimer::instance, async_wait(_)).WillRepeatedly(Return());
+
+    socket.setReadRateLimit(50);
+
+    std::function<void(const boost::system::error_code &, size_t)>
+        asyncReadHandler;
+
+    std::vector<uint8_t> data;
+    data.resize(128);
+    boost::asio::mutable_buffers_1 buffer(&data, 128);
+
+    {
+        // this will be invoked because we definitely haven't hit the limit yet
+        EXPECT_CALL(*MockSocket::instance,
+                    async_read_some(An<boost::asio::null_buffers>(), _))
+            .WillOnce(SaveArg<1>(&asyncReadHandler));
+
+        socket.async_read_some(
+            boost::asio::null_buffers(),
+            [&](const boost::system::error_code &error, size_t numBytes) {
+
+            });
+
+        asyncReadHandler(boost::system::error_code(), 55);
+
+        EXPECT_CALL(*MockSocket::instance, read_some(_, _))
+            .WillOnce(Return(55));
+
+        boost::system::error_code ec;
+        EXPECT_EQ(55, socket.read_some(buffer, ec));
+    }
+
+    {
+        // MockSocket.async_read_some will be invoked here because we do not
+        // trigger any data limiting on the first limit breach. This call will
+        // start the timers etc preparing to rate limit for real the next time
+        // this limit is hit
+        EXPECT_CALL(*MockSocket::instance,
+                    async_read_some(An<boost::asio::null_buffers>(), _))
+            .WillOnce(SaveArg<1>(&asyncReadHandler));
+        socket.async_read_some(
+            boost::asio::null_buffers(),
+            [&](const boost::system::error_code &error, size_t numBytes) {
+
+            });
+
+        EXPECT_CALL(*MockSocket::instance, read_some(_, _))
+            .WillOnce(Return(55));
+        boost::system::error_code ec;
+        EXPECT_EQ(55, socket.read_some(buffer, ec));
+    }
+
+    {
+        // We are expecting that MockSocket.async_read_some will not be invoked
+        // again because we've read_some'd up to our data rate limit without
+        // invoking the timer handler
+        socket.async_read_some(
+            boost::asio::null_buffers(),
+            [&](const boost::system::error_code &error, size_t numBytes) {
+
+            });
+    }
+}

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -156,8 +156,8 @@ class SessionTest : public ::testing::Test {
     SessionTest();
 
     std::shared_ptr<Session>
-    makeSession(MaybeSecureSocketAdaptor              &&clientSocket,
-                MaybeSecureSocketAdaptor              &&serverSocket,
+    makeSession(MaybeSecureSocketAdaptor<>              &&clientSocket,
+                MaybeSecureSocketAdaptor<>              &&serverSocket,
                 std::shared_ptr<AuthInterceptInterface> authIntercept = 0);
 
     void driveTo(int targetStep);
@@ -222,8 +222,8 @@ class SessionTest : public ::testing::Test {
 };
 
 std::shared_ptr<Session>
-SessionTest::makeSession(MaybeSecureSocketAdaptor              &&clientSocket,
-                         MaybeSecureSocketAdaptor              &&serverSocket,
+SessionTest::makeSession(MaybeSecureSocketAdaptor<>              &&clientSocket,
+                         MaybeSecureSocketAdaptor<>              &&serverSocket,
                          std::shared_ptr<AuthInterceptInterface> authIntercept)
 {
     if (!authIntercept) {


### PR DESCRIPTION
This commit changes MaybeSecureSocketAdaptor to template a few critical types which allows us to write unit tests against some of it's behaviours

In theory this could probably also replace the SocketIntercept things, which were a nice solution when the implementation of this class passed straight through to the asio types. I didn't look into what we'd need to do to replace that just yet.

Since working around some asio bugs https://github.com/bloomberg/amqpprox/pull/69 and adding support for data rate limits https://github.com/bloomberg/amqpprox/pull/88 the MaybeSecureSocketAdaptor class has expanded enough that we should be writing unit tests for it - and probably should have done so before now.