### PR TITLE
Fix the CI/Conan Build System

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,9 @@ jobs:
     steps:
       - name: Install Conan
         id: conan
-        uses: turtlebrowser/get-conan@v1.0
+        uses: turtlebrowser/get-conan@v1.1
+        with:
+          version: 1.59.0
     
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2

--- a/authproto/CMakeLists.txt
+++ b/authproto/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(Protobuf_USE_STATIC_LIBS ON)
 
+# XXX(acasey23): Can we revisit this when we get to conan 2? This feels like a bug in the protobuf conan package
+set(CMAKE_PROGRAM_PATH ${CMAKE_PROGRAM_PATH} ${CONAN_BIN_DIRS})
 include(FindProtobuf)
 find_package(Protobuf REQUIRED)
 

--- a/buildfiles/conan/conanfile.txt
+++ b/buildfiles/conan/conanfile.txt
@@ -2,7 +2,7 @@
 boost/1.76.0
 openssl/1.1.1k
 gtest/1.10.0
-protobuf/3.17.1
+protobuf/3.21.9
 
 [generators]
 cmake

--- a/buildfiles/conan/integration.Dockerfile
+++ b/buildfiles/conan/integration.Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y --force-yes python3.8 python3.8-distutils \
     curl llvm make cmake build-essential npm
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3.8 get-pip.py
-RUN python3.8 -m pip install setuptools conan robotframework pika amqp pytest
+RUN python3.8 -m pip install setuptools "conan<2.0" robotframework pika amqp pytest
 ENV HOME="/root" PATH="/root/.cargo/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 


### PR DESCRIPTION
Conan 2.0 seems to have a bunch of changes which this repo isn't quite ready for.

For now let's pin to Conan 1.59.0, and fix the protobuf issue.