### PR TITLE
Support OpenSSL 3.0+

### DIFF
--- a/buildfiles/conan/conanfile.txt
+++ b/buildfiles/conan/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost/1.76.0
-openssl/1.1.1k
+openssl/[>1.1.1k]
 gtest/1.10.0
 protobuf/3.21.9
 

--- a/libamqpprox/amqpprox_tlsutil.cpp
+++ b/libamqpprox/amqpprox_tlsutil.cpp
@@ -31,7 +31,9 @@ std::string TlsUtil::augmentTlsError(const boost::system::error_code &ec)
 
     if (ec.category() == boost::asio::error::get_ssl_category()) {
         err += " (" + std::to_string(ERR_GET_LIB(ec.value())) + "," +
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
                std::to_string(ERR_GET_FUNC(ec.value())) + "," +
+#endif
                std::to_string(ERR_GET_REASON(ec.value())) + ") ";
 
         char tempBuf[128];


### PR DESCRIPTION
This commit ifdefs out a bit of debug info which is apparently no longer useful in OpenSSL 3.0+.

Ref: https://openssl.org/news/cl30.txt

Closes #95 