### PR TITLE
Ensure partially read frame buffer is always large enough to hold frame

### DIFF
--- a/libamqpprox/amqpprox_session.h
+++ b/libamqpprox/amqpprox_session.h
@@ -342,8 +342,10 @@ inline void Session::copyRemaining(FlowType direction, const Buffer &remaining)
         if (remaining.size()) {
             d_serverWaterMark = remaining.size();
             d_serverWriteDataHandle.swap(d_serverDataHandle);
-            d_bufferPool_p->acquireBuffer(&d_serverDataHandle,
-                                          Frame::getMaxFrameSize());
+            d_bufferPool_p->acquireBuffer(
+                &d_serverDataHandle,
+                std::max(d_serverWaterMark, Frame::getMaxFrameSize()));
+
             memcpy(
                 d_serverDataHandle.data(), remaining.ptr(), d_serverWaterMark);
         }
@@ -355,8 +357,9 @@ inline void Session::copyRemaining(FlowType direction, const Buffer &remaining)
         if (remaining.size()) {
             d_clientWaterMark = remaining.size();
             d_clientWriteDataHandle.swap(d_clientDataHandle);
-            d_bufferPool_p->acquireBuffer(&d_clientDataHandle,
-                                          Frame::getMaxFrameSize());
+            d_bufferPool_p->acquireBuffer(
+                &d_clientDataHandle,
+                std::max(d_clientWaterMark, Frame::getMaxFrameSize()));
             memcpy(
                 d_clientDataHandle.data(), remaining.ptr(), d_clientWaterMark);
         }


### PR DESCRIPTION
amqpprox internally buffers partial frames until the full frame is in memory, at which point they are sent to the broker or client (depending on direction).

If there is no data internally buffered when data becomes available on the socket, amqpprox creates a buffer of exactly the required size. Sometimes - e.g. When amqpprox is quite busy - the requested buffer is larger than expected. This causes the partial-frame buffer swap operation to fail.