### PR TITLE
gtestupgrade fixes

### DIFF
--- a/tests/amqpprox_dnsresolver.t.cpp
+++ b/tests/amqpprox_dnsresolver.t.cpp
@@ -17,7 +17,6 @@
 #include <amqpprox_dnsresolver.h>
 
 #include <chrono>
-#include <gmock/gmock-generated-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <thread>

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -89,6 +89,16 @@ using ConnectComplete   = TestSocketState::ConnectComplete;
 
 const char LOCAL_HOSTNAME[] = "amqpprox-host";
 
+// To fix compilation error (gtest ver >=1.12.1) in EXPECT_THAT macro when
+// validating TestSocketState::Item. Since TestSocketState::Item is a variant,
+// googletest requires operator<< / PrintTo to be defined for every member of
+// the variant.
+void PrintTo(const TestSocketState::Func &, std::ostream *stream)
+{
+    *stream << "invoked PrintTo for object of type 'const "
+               "TestSocketState::Func'\n";
+}
+
 struct SelectorMock : public ConnectionSelectorInterface {
     virtual ~SelectorMock() {}
 


### PR DESCRIPTION
1) removed gtest hdr which does not exist 
2) defined operator << for the type validated in EXPECT_THAT macro.


