### PR TITLE
Check length of buffer

### DIFF
--- a/libamqpprox/amqpprox_method.cpp
+++ b/libamqpprox/amqpprox_method.cpp
@@ -21,6 +21,11 @@ namespace amqpprox {
 bool Method::decode(Method *method, const void *buffer, std::size_t bufferLen)
 {
     const uint8_t *buf = static_cast<const uint8_t *>(buffer);
+
+    if (bufferLen < sizeof(method->classType) + sizeof(method->classType)) {
+        return false;
+    }
+
     memcpy(&method->classType, buf, sizeof(method->classType));
     memcpy(&method->methodType,
            buf + sizeof(method->classType),

--- a/libamqpprox/amqpprox_method.cpp
+++ b/libamqpprox/amqpprox_method.cpp
@@ -22,7 +22,7 @@ bool Method::decode(Method *method, const void *buffer, std::size_t bufferLen)
 {
     const uint8_t *buf = static_cast<const uint8_t *>(buffer);
 
-    if (bufferLen < sizeof(method->classType) + sizeof(method->classType)) {
+    if (bufferLen < sizeof(method->classType) + sizeof(method->methodType)) {
         return false;
     }
 

--- a/tests/amqpprox_packetprocessor.t.cpp
+++ b/tests/amqpprox_packetprocessor.t.cpp
@@ -83,6 +83,30 @@ TEST_F(PacketProcessorTest, HeaderPassedInOne)
     EXPECT_THAT(d_connector.state(), Eq(Connector::State::START_SENT));
 }
 
+TEST_F(PacketProcessorTest, MalformedStartOk)
+{
+    PacketProcessor processor(d_sessionState, d_connector);
+
+    // Header
+    {
+        Buffer buffer((const void *)Constants::protocolHeader(),
+                      Constants::protocolHeaderLength());
+        buffer.seek(Constants::protocolHeaderLength());
+
+        processor.process(FlowType::INGRESS, buffer);
+    }
+
+    {
+        const uint8_t data[] = {
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xce};
+        size_t size = sizeof(data) / sizeof(*data);
+        Buffer buffer(data, size);
+        buffer.seek(size);
+
+        processor.process(FlowType::INGRESS, buffer);
+    }
+}
+
 TEST_F(PacketProcessorTest, IncompleteHeader)
 {
     // If we give the PacketProcessor less than the full header, we shouldn't


### PR DESCRIPTION
**Describe your changes**
Check the buffer length before reading bytes off the buffer.

**Testing performed**
I added a unit test that exposes the overflow. It fails in an ASAN build without the fix, and succeeds with the fix.

**Additional context**
This doesn't cause an ASAN failure when sending the bytes to the running server, since the memory region allocated to hold the wire bytes is much larger than what is actually sent by the client. The bytes read though are uninitialized regardless.
