### PR TITLE
Add missing headers

### DIFF
--- a/libamqpprox/amqpprox_backendset.h
+++ b/libamqpprox/amqpprox_backendset.h
@@ -18,6 +18,7 @@
 
 #include <amqpprox_backend.h>
 
+#include <cstdint>
 #include <vector>
 
 namespace Bloomberg {

--- a/libamqpprox/amqpprox_connectionmanager.h
+++ b/libamqpprox/amqpprox_connectionmanager.h
@@ -18,6 +18,7 @@
 
 #include <amqpprox_backendset.h>
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/libamqpprox/amqpprox_types.cpp
+++ b/libamqpprox/amqpprox_types.cpp
@@ -23,6 +23,8 @@
 
 #include <boost/endian/arithmetic.hpp>
 
+#include <cstdint>
+
 // Note this is not 'pure' AMQP 0-9-1  aiming for the same compatibility as the
 // server see https://www.rabbitmq.com/amqp-0-9-1-errata.html &
 // https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbit_common/src/rabbit_binary_parser.erl

--- a/libamqpprox/amqpprox_types.h
+++ b/libamqpprox/amqpprox_types.h
@@ -16,6 +16,7 @@
 #ifndef BLOOMBERG_AMQPPROX_TYPES
 #define BLOOMBERG_AMQPPROX_TYPES
 
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <vector>


### PR DESCRIPTION
**Describe your changes**
- These files need to be directly included, as we directly use the types that are only found via these files.
- They were likely previously transitively included.
