### PR TITLE
Set classId & methodId for Close method 

### DIFF
--- a/libamqpprox/amqpprox_connector.cpp
+++ b/libamqpprox/amqpprox_connector.cpp
@@ -326,9 +326,12 @@ void Connector::synthesizeCloseError(bool sendToIngressSide)
 
 void Connector::synthesizeCustomCloseError(bool             sendToIngressSide,
                                            uint16_t         code,
-                                           std::string_view text)
+                                           std::string_view text,
+                                           uint16_t         classId,
+                                           uint16_t         methodId)
 {
-    synthesizeMessage(d_close, sendToIngressSide, code, text);
+    synthesizeMessage(
+        d_close, sendToIngressSide, code, text, classId, methodId);
 }
 
 Buffer Connector::outBuffer()
@@ -416,10 +419,12 @@ void Connector::sendResponse(const T &response, bool sendToIngressSide)
 void Connector::synthesizeMessage(methods::Close  &replyMethod,
                                   bool             sendToIngressSide,
                                   uint64_t         code,
-                                  std::string_view text)
+                                  std::string_view text,
+                                  uint16_t         classId,
+                                  uint16_t         methodId)
 {
     d_buffer = Buffer();  // forget inbound buffer
-    replyMethod.setReply(code, std::string(text));
+    replyMethod.setReply(code, std::string(text), classId, methodId);
     sendResponse(replyMethod, sendToIngressSide);
 }
 

--- a/libamqpprox/amqpprox_connector.h
+++ b/libamqpprox/amqpprox_connector.h
@@ -105,7 +105,9 @@ class Connector {
     inline void synthesizeMessage(methods::Close  &replyMethod,
                                   bool             sendToIngressSide,
                                   uint64_t         code,
-                                  std::string_view text);
+                                  std::string_view text,
+                                  uint16_t         classId  = 0,
+                                  uint16_t         methodId = 0);
 
   public:
     Connector(SessionState    *sessionState,
@@ -167,10 +169,14 @@ class Connector {
      * for communicating with server
      * \param code custom error code
      * \param text custom error text
+     * \param classId custom class id
+     * \param methodId custom method id
      */
     void synthesizeCustomCloseError(bool             sendToIngressSide,
                                     uint16_t         code,
-                                    std::string_view text);
+                                    std::string_view text,
+                                    uint16_t         classId  = 0,
+                                    uint16_t         methodId = 0);
 
     /**
      * \brief Synthesize AMQP protocol header buffer, which will eventually be

--- a/libamqpprox/amqpprox_dnsresolver.h
+++ b/libamqpprox/amqpprox_dnsresolver.h
@@ -52,8 +52,8 @@ struct PairHash {
 class DNSResolver {
     using TcpEndpoint = boost::asio::ip::tcp::endpoint;
     using CacheType   = std::unordered_map<std::pair<std::string, std::string>,
-                                         std::vector<TcpEndpoint>,
-                                         PairHash>;
+                                           std::vector<TcpEndpoint>,
+                                           PairHash>;
 
   public:
     using OverrideFunction =

--- a/libamqpprox/amqpprox_hostnamemapper.h
+++ b/libamqpprox/amqpprox_hostnamemapper.h
@@ -26,7 +26,7 @@ namespace amqpprox {
  */
 class HostnameMapper {
   public:
-    virtual ~HostnameMapper(){};
+    virtual ~HostnameMapper() {};
 
     /**
      * \brief prime the cache of hostnames with a list of endpoints

--- a/libamqpprox/amqpprox_maybesecuresocketadaptor.h
+++ b/libamqpprox/amqpprox_maybesecuresocketadaptor.h
@@ -131,15 +131,9 @@ class MaybeSecureSocketAdaptor
         src.d_dataRateTimer->cancel();
     }
 
-    ~MaybeSecureSocketAdaptor()
-    {
-        d_dataRateTimer->cancel();
-    }
+    ~MaybeSecureSocketAdaptor() { d_dataRateTimer->cancel(); }
 
-    boost::asio::ip::tcp::socket &socket()
-    {
-        return d_socket->next_layer();
-    }
+    boost::asio::ip::tcp::socket &socket() { return d_socket->next_layer(); }
 
     void setSecure(bool secure)
     {

--- a/libamqpprox/amqpprox_methods_close.h
+++ b/libamqpprox/amqpprox_methods_close.h
@@ -46,10 +46,24 @@ class Close {
 
     const uint16_t methodId() const { return d_methodId; }
 
-    inline void setReply(uint16_t code, const std::string &text)
+    inline void setReply(uint16_t           code,
+                         const std::string &text,
+                         uint16_t           classId  = 0,
+                         uint16_t           methodId = 0)
     {
         d_replyCode   = code;
         d_replyString = text;
+
+        // Close may be due to internal conditions or due to an exception
+        // during handling a specific method. When a close is due to an
+        // exception, the class and method id of the method which caused the
+        // exception is provided.
+        if (classId) {
+            d_classId = classId;
+        }
+        if (methodId) {
+            d_methodId = methodId;
+        }
     }
 
     /**

--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -627,7 +627,9 @@ void Session::disconnectUnauthClient(const FieldTable &clientProperties,
                 d_connector.synthesizeCustomCloseError(
                     true,
                     Reply::Codes::access_refused,
-                    reason.substr(0, sendSize));
+                    reason.substr(0, sendSize),
+                    methods::StartOk::classType(),
+                    methods::StartOk::methodType());
                 sendSyntheticData();
             }
         }

--- a/tests/amqpprox_farmstore.t.cpp
+++ b/tests/amqpprox_farmstore.t.cpp
@@ -80,8 +80,8 @@ TEST(FarmStore, GettingMissingFarm)
 {
     FarmStore farmStore;
 
-    EXPECT_THROW({ farmStore.getFarmByName("nosuchfarm"); },
-                 std::runtime_error);
+    EXPECT_THROW(
+        { farmStore.getFarmByName("nosuchfarm"); }, std::runtime_error);
 }
 
 TEST(FarmStore, AddTwice)

--- a/tests/amqpprox_maybesecuresocketadaptor.t.cpp
+++ b/tests/amqpprox_maybesecuresocketadaptor.t.cpp
@@ -47,7 +47,7 @@ class SocketInterface {
     virtual size_t read_some(const boost::asio::mutable_buffers_1 &buffer,
                              boost::system::error_code            &error) = 0;
 
-    virtual ~SocketInterface(){};
+    virtual ~SocketInterface() {};
 };
 
 class MockSocket : public SocketInterface {
@@ -76,7 +76,7 @@ class MockSocket : public SocketInterface {
 
 class TimerInterface {
   public:
-    virtual ~TimerInterface(){};
+    virtual ~TimerInterface() {};
     virtual void cancel() = 0;
 
     virtual size_t

--- a/tests/amqpprox_session.t.cpp
+++ b/tests/amqpprox_session.t.cpp
@@ -1455,7 +1455,9 @@ TEST_F(SessionTest,
     std::shared_ptr<methods::Close> closeMethodPtr =
         std::make_shared<methods::Close>();
     closeMethodPtr->setReply(Reply::Codes::access_refused,
-                             "Unauthorized test client");
+                             "Unauthorized test client",
+                             methods::StartOk::classType(),
+                             methods::StartOk::methodType());
     testSetupClientOpenWithProxyClose(4, closeMethodPtr);
 
     std::shared_ptr<MaybeSecureSocketAdaptor<>> clientSocket =


### PR DESCRIPTION
## Overview
- set class id and method id on connection close to give clients the information about the method that caused an "exception" leading to connection close
- [[read more]](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#--------close------------------------------------reply-codereply-code----------------------------------------------------reply-textreply-text----------------------------------------------------class-idclass-id----------------------------------------------------method-idmethod-id------------------------close-ok------------) close in amqp protocol
  - class id: `When the close is provoked by a method exception, this is the class of the method.`
  - method id:  `When the close is provoked by a method exception, this is the ID of the method.`
- class id and method id for authentication failure are set to 10/11 i.e. connection/start-ok, as:
  - [[code]](https://github.com/bloomberg/amqpprox/blob/5fc9270da9acea86216c1110ef478cdf4a558733/libamqpprox/amqpprox_connector.cpp#L468) proxy extracts credentials from the response field in connection/start-ok
  - [[code]](https://github.com/bloomberg/amqpprox/blob/5fc9270da9acea86216c1110ef478cdf4a558733/libamqpprox/amqpprox_session.cpp#L553-L561) these credentials are POSTed to auth service
  - [[code]](https://github.com/bloomberg/amqpprox/blob/5fc9270da9acea86216c1110ef478cdf4a558733/libamqpprox/amqpprox_session.cpp#L517) in case authentication is failed, it is an "exception" in connection/start-ok, causing connection/close
- [[read more]](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/main/docs/amqp-0-9-1-reference.md#--------start-ok------------------------------------peer-propertiesclient-properties----------------------------------------------------shortstrmechanism----------------------------------------------------longstrresponse----------------------------------------------------shortstrlocale------------------------------------) start-ok in amqp protocol
  - response: `opaque data passed to the security mechanism` 
- raw protocol
  - [start-ok](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/b8e975a762b8677263ebbbba1e70654b5263af81/xml/amqp0-9-1.xml#L578) method=11 present in class=10 explaining `response` field
  - [close](https://github.com/rabbitmq/amqp-0.9.1-spec/blob/b8e975a762b8677263ebbbba1e70654b5263af81/xml/amqp0-9-1.xml#L833) method=50 present in class=10 explaining `classId` and `methodId` field

## Testing
- [x] Unit Tests