### PR TITLE
Don't pessimize moves

### DIFF
--- a/libamqpprox/amqpprox_eventsourcesignal.h
+++ b/libamqpprox/amqpprox_eventsourcesignal.h
@@ -179,7 +179,8 @@ EventSourceSignal<ARGS...>::create()
 {
     std::shared_ptr<EventSourceSignal<ARGS...>> signal(
         new EventSourceSignal());
-    return std::move(signal);
+
+    return signal;
 }
 
 }


### PR DESCRIPTION
Removing explicit std::move on a local variable in a return statement allows the compiler to apply Named Return Value Optimization (NRVO). The explicit std::move actually prevents copy elision.
