### PR TITLE
Bump cmake_minimum_required to 3.27 in preparation for v4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.27.0)
 
 project(amqpprox)
 


### PR DESCRIPTION
Pick a more modern minimum before upgrading to CMake v4 in future. CMake 3.27 significantly improves compatibility with CMake 4.x while presenting little risk to existing builds.
