### PR TITLE
Fix static linking of protobuf and pre-build perf tester

### DIFF
--- a/authproto/CMakeLists.txt
+++ b/authproto/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(Protobuf_USE_STATIC_LIBS ON)
+
 find_package(protobuf REQUIRED CONFIG)
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS sasl.proto authrequest.proto authresponse.proto)

--- a/buildfiles/conan/integration.Dockerfile
+++ b/buildfiles/conan/integration.Dockerfile
@@ -28,6 +28,8 @@ RUN npm install
 WORKDIR /source
 
 RUN make setup && make init && make
+RUN cargo build --release --manifest-path tests/performance_tester/Cargo.toml
+ENV PERF_TESTER_BIN=/source/tests/performance_tester/target/release/amqpprox_perf_tester
 ENV ROBOT_SOURCE_DIR=/source/tests/acceptance ROBOT_BINARY_DIR=/opt/rabbitmq/sbin
 ENV AMQPPROX_BIN_DIR=/build/bin
 ENV NODE_OPTIONS=--dns-result-order=ipv4first

--- a/tests/performance_tester/integration-tests.py
+++ b/tests/performance_tester/integration-tests.py
@@ -67,14 +67,13 @@ def run_perf_test_command(amqpprox_url, message_size, num_messages, max_threads,
     env = os.environ.copy()
     env["RUST_LOG"] = "info"
 
+    perf_tester_bin = os.environ.get("PERF_TESTER_BIN")
+    if not perf_tester_bin:
+        raise RuntimeError("PERF_TESTER_BIN environment variable must be set")
+
     return subprocess.run(
         [
-            env.get("CARGO_PATH", "cargo"),
-            "run",
-            "--release",
-            "--manifest-path",
-            "tests/performance_tester/Cargo.toml",
-            "--",
+            perf_tester_bin,
             "--address",
             amqpprox_url,
             "--listen-address",


### PR DESCRIPTION
Restore `set(Protobuf_USE_STATIC_LIBS ON)` in authproto/CMakeLists.txt. This was inadvertently removed in PR #114 when modernising the find_package call. Without it, protobuf is linked dynamically, causing runtime failures on systems without the shared library installed.

Also pre-build the Rust performance tester binary in the integration Dockerfile and require the PERF_TESTER_BIN environment variable in integration-tests.py. This avoids needing a full Rust toolchain in the test runtime environment and gives explicit control over the binary being tested.
