### PR TITLE
Add `connectionName` field and structured log format for sessions

### DIFF
--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -100,6 +100,17 @@ std::ostream &operator<<(std::ostream &os, const ConnectionSummary &cs)
     return cs.print(os);
 }
 
+std::string getConnectionName(const Connector &connector)
+{
+    FieldValue fv('S', std::string());
+    if (connector.getClientProperties().findFieldValue(&fv,
+                                                       "connection_name") &&
+        fv.type() == 'S') {
+        return fv.value<std::string>();
+    }
+    return {};
+}
+
 void logException(const std::string_view error,
                   const SessionState    &sessionState,
                   FlowType               direction)
@@ -368,9 +379,13 @@ void Session::attemptEndpointConnection(
 
             d_clientSocket->setSecure(currentBackend->tlsEnabled());
 
-            LOG_INFO << "Starting "
-                     << (currentBackend->tlsEnabled() ? "secured " : "")
-                     << "connection for: " << d_sessionState;
+            const auto connectionName = getConnectionName(d_connector);
+
+            LOG_INFO << "Starting connection for:"
+                     << " connectionName=\"" << connectionName << "\""
+                     << " tlsEnabled="
+                     << (currentBackend->tlsEnabled() ? "secured" : "insecure")
+                     << " " << d_sessionState;
 
             auto self(shared_from_this());
             auto handshake_cb =

--- a/libamqpprox/amqpprox_sessionstate.cpp
+++ b/libamqpprox/amqpprox_sessionstate.cpp
@@ -17,7 +17,6 @@
 
 #include <amqpprox_hostnamemapper.h>
 
-#include <iomanip>
 #include <iostream>
 
 #include <boost/lexical_cast.hpp>
@@ -212,32 +211,29 @@ std::ostream &operator<<(std::ostream &os, const SessionState &state)
                     &egressLatencyTotal,
                     &egressLatencyCount);
 
-    os << std::setw(7) << state.id() << ": "
-       << "vhost=" << state.getVirtualHost() << " "
-       << ", "
+    os << "id=" << state.id() << " vhost=" << state.getVirtualHost()
+       << " disconnected="
        << (state.getDisconnectType() ==
                    SessionState::DisconnectType::NOT_DISCONNECTED
-               ? ""
-               : "D")
-       << (state.getPaused() ? "P " : " ")
-       << (state.getAuthDeniedConnection() ? "DENY " : " ")
-       << state.hostname(state.getIngress().second) << ":"
-       << state.getIngress().second.port() << "->"
-       << state.hostname(state.getIngress().first) << " --> "
-       << state.hostname(state.getEgress().first) << ":"
-       << state.getEgress().first.port() << "->"
-       << state.hostname(state.getEgress().second) << ":"
-       << state.getEgress().second.port() << " IN: " << ingressBytes << "B "
-       << ingressFrames << " Frames in " << ingressPackets << " pkt. ";
+               ? "N"
+               : "Y")
+       << " paused=" << (state.getPaused() ? "Y" : "N")
+       << " authDenied=" << (state.getAuthDeniedConnection() ? "Y" : "N")
+       << " ingressRemote=" << state.hostname(state.getIngress().second) << ":"
+       << state.getIngress().second.port()
+       << " ingressLocal=" << state.hostname(state.getIngress().first)
+       << " egressLocal=" << state.hostname(state.getEgress().first) << ":"
+       << state.getEgress().first.port()
+       << " egressRemote=" << state.hostname(state.getEgress().second) << ":"
+       << state.getEgress().second.port() << " inBytes=" << ingressBytes
+       << " inFrames=" << ingressFrames << " inPackets=" << ingressPackets;
     if (ingressLatencyCount > 0) {
-        os << " Avg. Latency: " << ingressLatencyTotal / ingressLatencyCount
-           << "ms ";
+        os << " inAvgLatencyMs=" << ingressLatencyTotal / ingressLatencyCount;
     }
-    os << " OUT: " << egressBytes << "B " << egressFrames << " Frames in "
-       << egressPackets << " pkt. ";
+    os << " outBytes=" << egressBytes << " outFrames=" << egressFrames
+       << " outPackets=" << egressPackets;
     if (egressLatencyCount > 0) {
-        os << " Avg. Latency: " << egressLatencyTotal / egressLatencyCount
-           << "ms ";
+        os << " outAvgLatencyMs=" << egressLatencyTotal / egressLatencyCount;
     }
 
     return os;

--- a/tests/acceptance/connection.robot
+++ b/tests/acceptance/connection.robot
@@ -142,3 +142,9 @@ Connection closed by proxy for RabbitMQ Consumer
 
     RabbitMQ has log  nodename=shared1  content=accepting AMQP connection
     RabbitMQ has log  nodename=shared1  content=closing AMQP connection
+
+Starting connection log contains connection name and TLS status
+    Start AMQPClient  name=connection_close
+
+    Wait Until Keyword Succeeds  10s  1s
+    ...    AMQPProx has log  Starting connection for: connectionName="my-test-app" tlsEnabled=insecure

--- a/tests/acceptance/libs/AMQPProx.robot
+++ b/tests/acceptance/libs/AMQPProx.robot
@@ -29,6 +29,11 @@ AMQPProx stop
     [Arguments]  ${handle}
     ${result} =  Terminate Process  ${handle}
 
+AMQPProx has log
+    [Arguments]    ${content}
+    ${logContent}=    Run Process  cat /tmp/logs/amqpprox/*  shell=yes
+    Should Contain  ${logContent.stdout}  ${content}
+
 AMQPProx print logs
     [Documentation]     Only for debug purposes
     ${result}=  Run Process  tail -n 120 /tmp/logs/amqpprox/*  shell=yes

--- a/tests/acceptance/libs/amqp_client/connection_close.py
+++ b/tests/acceptance/libs/amqp_client/connection_close.py
@@ -32,6 +32,9 @@ class AMQPClientConnection(object):
         LOGGER.info("creating connection")
         self.connection = Connection(host=host,
                                      heartbeat=4,
+                                     client_properties={
+                                         'connection_name': 'my-test-app',
+                                     },
                                      on_open=self.on_open,
                                      on_blocked=self.on_blocked,
                                      on_unblocked=self.on_unblocked,


### PR DESCRIPTION
The "Starting connection" log line now includes the AMQP client's `connection_name` property as a key=value field, making it easy to identify which application established a connection when ingesting logs into observability tooling.

The TLS status and `SessionState` output are also reformatted as consistent key=value pairs for easier log ingestion.

An integration test has been added to verify the `connectionName` and `tlsEnabled` fields appear in the "Starting connection" log line.

eg. From the tests
```
Starting connection for: connectionName="my-test-app" tlsEnabled=insecure id=1 vhost=/ disconnected=N paused=N authDenied=N ingressRemote=127.0.0.1:36678 ingressLocal=127.0.0.1 egressLocal=127.0.0.1:39452 egressRemote=127.0.0.1:5800 inBytes=0 inFrames=0 inPackets=0 inAvgLatencyMs=0 outBytes=0 outFrames=0 outPackets=0
```
