### PR TITLE
issues/121: fix dockerfile

### DIFF
--- a/buildfiles/conan/clang.Dockerfile
+++ b/buildfiles/conan/clang.Dockerfile
@@ -1,5 +1,22 @@
-FROM conanio/clang9 AS amqpprox_build_environment
-RUN sudo apt-get update && sudo apt-get install -y llvm
+FROM ubuntu:24.04 AS amqpprox_build_environment
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    ninja-build \
+    build-essential \
+    pkg-config \
+    python3 \
+    python3-pip \
+    python3-venv \
+    llvm \
+    clang \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages "conan>=2,<3"
+
 WORKDIR /source
 ENV BUILDDIR=/build
-ENV CONAN_USER_HOME=/build
+ENV CONAN_HOME=/build/.conan2

--- a/buildfiles/conan/conanfile.txt
+++ b/buildfiles/conan/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost/1.76.0
-openssl/[>1.1.1k]
+openssl/[>1.1.1k <4]
 gtest/1.10.0
 protobuf/3.21.9
 

--- a/buildfiles/conan/gcc.Dockerfile
+++ b/buildfiles/conan/gcc.Dockerfile
@@ -1,4 +1,21 @@
-FROM conanio/gcc9 AS amqpprox_build_environment
+FROM ubuntu:24.04 AS amqpprox_build_environment
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    cmake \
+    ninja-build \
+    build-essential \
+    pkg-config \
+    python3 \
+    python3-pip \
+    python3-venv \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --break-system-packages "conan>=2,<3"
+
 WORKDIR /source
 ENV BUILDDIR=/build
-ENV CONAN_USER_HOME=/build
+ENV CONAN_HOME=/build/.conan2


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #121*

**Describe your changes**
Fixed the Docker-based build (make docker-setup / make docker-init) which was failing because the conanio/clang9 and conanio/gcc9 base images ship with CMake 3.18.2, while the project requires CMake 3.27.0 or higher
