### PR TITLE
Forward client host and connection name to auth request

### DIFF
--- a/authproto/authrequest.proto
+++ b/authproto/authrequest.proto
@@ -23,4 +23,6 @@ package Bloomberg.amqpprox.authproto;
 message AuthRequest {
     string vhostName = 1;
     SASL authData = 2;
+    string clientHostname = 3;
+    string connectionName = 4;
 }

--- a/libamqpprox/amqpprox_session.cpp
+++ b/libamqpprox/amqpprox_session.cpp
@@ -568,6 +568,9 @@ void Session::establishConnection()
     // Initialize auth request data
     authproto::AuthRequest authRequestData;
     authRequestData.set_vhostname(d_sessionState.getVirtualHost());
+    authRequestData.set_clienthostname(
+        d_sessionState.hostname(d_sessionState.getIngress().second));
+    authRequestData.set_connectionname(getConnectionName(d_connector));
     authproto::SASL *saslPtr = authRequestData.mutable_authdata();
     saslPtr->set_authmechanism(sasl.first);
     saslPtr->set_credentials(sasl.second);

--- a/tests/amqpprox_httpauthintercept.t.cpp
+++ b/tests/amqpprox_httpauthintercept.t.cpp
@@ -16,6 +16,9 @@
 
 #include <amqpprox_httpauthintercept.h>
 
+#include <authrequest.pb.h>
+#include <sasl.pb.h>
+
 #include <gmock/gmock.h>
 
 #include <iostream>
@@ -47,4 +50,31 @@ TEST(HttpAuthIntercept, Print)
     EXPECT_EQ(oss.str(),
               "HTTP Auth service will be used to authn/authz client "
               "connections: http://localhost:8080/target\n");
+}
+
+TEST(HttpAuthIntercept, AuthRequestCarriesClientHostnameAndConnectionName)
+{
+    // The client's originating host and AMQP connection name are forwarded to
+    // the auth gate as new proto3 fields. Verify they survive a serialize /
+    // parse round-trip alongside the pre-existing fields.
+    authproto::AuthRequest request;
+    request.set_vhostname("my-vhost");
+    request.set_clienthostname("client-host.example.com");
+    request.set_connectionname("my-connection");
+    authproto::SASL *sasl = request.mutable_authdata();
+    sasl->set_authmechanism("PLAIN");
+    sasl->set_credentials(std::string("\0user\0pass", 10));
+
+    std::string serialized;
+    ASSERT_TRUE(request.SerializeToString(&serialized));
+
+    authproto::AuthRequest parsed;
+    ASSERT_TRUE(parsed.ParseFromString(serialized));
+
+    EXPECT_EQ(parsed.vhostname(), "my-vhost");
+    EXPECT_EQ(parsed.clienthostname(), "client-host.example.com");
+    EXPECT_EQ(parsed.connectionname(), "my-connection");
+    EXPECT_EQ(parsed.authdata().authmechanism(), "PLAIN");
+    EXPECT_EQ(parsed.authdata().credentials(),
+              std::string("\0user\0pass", 10));
 }


### PR DESCRIPTION
**Describe your changes**
- Add clientHostname and connectionName as new proto3 fields on AuthRequest and populate them from the session's ingress remote endpoint and the AMQP connection_name client property.
- These are additive fields with fresh tag numbers, so the change is wire-compatible. 

**Testing performed**
- Unit tests

**Additional context**
Add any other context about your contribution here.
